### PR TITLE
During first boot, don't remove existing xorg.conf. (LP: #1307546)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-drivers-common (1:0.2.91.5) UNRELEASED; urgency=medium
+
+  * During first boot, don't remove existing xorg.conf. (LP: #1307546)
+
+ -- Mario Limonciello <superm1@ubuntu.com>  Fri, 18 Apr 2014 11:35:27 -0500
+
 ubuntu-drivers-common (1:0.2.91.4) trusty; urgency=medium
 
   * Force removal of jockey on upgrades. It has been replaced with

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1485,9 +1485,11 @@ static int read_data_from_file(struct device **devices,
     FILE *pfile = NULL;
     /* The number of digits we expect to match per line */
     int desired_matches = 7;
+    int created = 1;
 
     pfile = fopen(filename, "r");
     if (pfile == NULL) {
+        created = 2;
         fprintf(log_handle, "I couldn't open %s for reading.\n", filename);
         /* Create the file for the 1st time */
         pfile = fopen(filename, "w");
@@ -1524,7 +1526,7 @@ static int read_data_from_file(struct device **devices,
     }
 
     fclose(pfile);
-    return 1;
+    return created;
 }
 
 
@@ -2270,6 +2272,7 @@ int main(int argc, char *argv[]) {
 
     int has_intel = 0, has_amd = 0, has_nvidia = 0;
     int has_changed = 0;
+    int first_boot = 0;
     int has_moved_xorg_conf = 0;
     int nvidia_loaded = 0, fglrx_loaded = 0,
         intel_loaded = 0, radeon_loaded = 0,
@@ -2695,6 +2698,8 @@ int main(int argc, char *argv[]) {
         fprintf(log_handle, "Can't read %s\n", last_boot_file);
         goto end;
     }
+    else if (status == 2)
+        first_boot = 1;
 
     fprintf(log_handle, "last cards number = %d\n", last_cards_n);
 
@@ -2899,7 +2904,7 @@ int main(int argc, char *argv[]) {
         }
 
         /* Move away xorg.conf */
-        if (has_changed) {
+        if (has_changed && !first_boot) {
             /* Either a desktop or a muxed laptop */
             fprintf(log_handle, "System configuration has changed\n");
 


### PR DESCRIPTION
This is a fix for this launchpad bug: https://bugs.launchpad.net/ubuntu/+source/ubuntu-release-upgrader/+bug/1307546
