### PR TITLE
gpu-manager.c: add nvidiaXineramaInfo off for Nvidia(lp#1653592)

### DIFF
--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1900,6 +1900,7 @@ static bool write_prime_xorg_conf(struct device **devices, int cards_n) {
                 "    Driver \"nvidia\"\n"
                 "    BusID \"PCI:%d@%d:%d:%d\"\n"
                 "    Option \"ConstrainCursor\" \"off\"\n"
+                "    Option \"nvidiaXineramaInfo\" \"off\"\n"
                 "EndSection\n\n"
                 "Section \"Screen\"\n"
                 "    Identifier \"nvidia\"\n"


### PR DESCRIPTION
as the suggestion from Nvidia to disable nvidiaXineramaInfo, so that could fix the issue that caused incorrect resolution when boot with external HDMI be plugged.