### PR TITLE
gpu-manager.c: remove dependency of dpkg-architecture from package dp…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-drivers-common (1:0.8.2) UNRELEASED; urgency=medium
+
+  * gpu-manager.c: remove dependency of dpkg-architecture from
+    package dpkg-dev (LP: #1875339).
+
+ -- Yuan-Chen Cheng <yc.cheng@canonical.com>  Fri, 01 May 2020 10:16:39 +0800
+
 ubuntu-drivers-common (1:0.8.1) focal; urgency=medium
 
   [ Alberto Milone ]

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -1335,19 +1335,21 @@ static bool run_amdgpu_pro_px(amdgpu_pro_px_action action) {
 
 static bool create_prime_outputclass(void) {
     _cleanup_fclose_ FILE *file = NULL;
-    _cleanup_free_ char *multiarch = NULL;
+    _cleanup_free_ char *machine = NULL;
+    char multiarch[30];
     char command[100];
     char xorg_d_custom[PATH_MAX];
 
     snprintf(xorg_d_custom, sizeof(xorg_d_custom), "%s/11-nvidia-prime.conf",
              xorg_conf_d_path);
 
-    snprintf(command, sizeof(command),
-             "/usr/bin/dpkg-architecture -qDEB_HOST_MULTIARCH");
+    snprintf(command, sizeof(command), "uname -m"); // x86_64, etc.
 
-    multiarch = get_output(command, NULL, NULL);
-    if (!multiarch)
+    machine = get_output(command, NULL, NULL);
+    if (!machine)
         return false;
+
+    snprintf(multiarch, sizeof(multiarch), "%s-linux-gnu", machine); // x86_64, etc.
 
     fprintf(log_handle, "Creating %s\n", xorg_d_custom);
     file = fopen(xorg_d_custom, "w");


### PR DESCRIPTION
call uname instead of dpkg-architecture.

fix bug LP: #1875339