### PR TITLE
Impish wip

### DIFF
--- a/ubiquity/target-config/31ubuntu_driver_packages
+++ b/ubiquity/target-config/31ubuntu_driver_packages
@@ -7,7 +7,17 @@ set -e
 PKGLIST=/run/ubuntu-drivers.autoinstall
 [ -e $PKGLIST ] || exit 0
 
-for p in `cat $PKGLIST`; do
-    apt-install $p
-done
+
+unset DEBIAN_HAS_FRONTEND
+export DEBIAN_FRONTEND=noninteractive
+unset DEBCONF_FRONTEND
+unset DEBCONF_REDIR
+export DEBCONF_ADMIN_EMAIL=
+export APT_LISTCHANGES_FRONTEND=none
+
+if [ -e /run/nvidia_runtimepm_supported ] && [ -e /target/run ]; then
+    cp /run/nvidia_runtimepm_supported /target/run/nvidia_runtimepm_supported
+fi
+
+chroot /target ubuntu-drivers install </dev/null
 

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -141,6 +141,7 @@ def command_install(args):
         print(ex)
         return 1
 
+    with_nvidia_kms = False
     is_nvidia = False
 
     packages = UbuntuDrivers.detect.system_driver_packages(
@@ -191,8 +192,17 @@ def command_install(args):
             f.write('\n')
             return 0
 
-    # Enable KMS if we are on Wayland
-    if is_nvidia and UbuntuDrivers.detect.is_wayland_session():
+    # Enable KMS if nvidia >= 470
+    for package in to_install:
+        if package.startswith('nvidia-driver-'):
+            try:
+                version = int(package.split('-')[-1])
+            except:
+                pass
+            finally:
+                with_nvidia_kms = version >= 470
+
+    if with_nvidia_kms:
         UbuntuDrivers.detect.set_nvidia_kms(1)
 
     ret = subprocess.call(['apt-get', 'install', '-o',


### PR DESCRIPTION
Call ubuntu-drivers in the chroot from the target-config, instead of simply using apt-install.

Also, enable KMS if the driveris 470 or newer. This only applies to the desktop drivers (we don't need KMS for the --gpgpu use case).