### PR TITLE
Impish ubiquity

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+ubuntu-drivers-common (1:0.9.2.2) impish; urgency=medium
+
+  * ubuntu-drivers:
+    - Make sure --package-list doesn't try to install packages.
+    - Enable KMS Wayland if nvidia >= 470. This only affects
+      the UDA drivers. This is more effective than checking
+      if Wayland is running, since the live image uses X11.
+  * UbuntuDrivers/detect.py:
+    - Add newline when setting kms.
+  * ubiquity/target-config/31ubuntu_driver_packages:
+    - Install nvidia-prime, so that we can handle hybrid
+      systems, and pick up the NVIDIA driver configuration
+      (LP: #1943816).
+
+ -- Alberto Milone <alberto.milone@canonical.com>  Fri, 08 Oct 2021 15:40:04 +0200
+
 ubuntu-drivers-common (1:0.9.2.1) impish; urgency=medium
 
   * UbuntuDrivers/detect.py:

--- a/debian/control
+++ b/debian/control
@@ -49,6 +49,7 @@ Depends: ${python3:Depends},
  pciutils,
  usbutils,
  kmod | module-init-tools,
+Recommends: nvidia-prime
 Suggests: python3-aptdaemon.pkcompat
 Replaces: nvidia-common (<< 1:0.2.46), jockey-common, jockey-gtk, jockey-kde
 Conflicts: nvidia-common (<< 1:0.2.46), jockey-common, jockey-gtk, jockey-kde

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -198,20 +198,17 @@ def command_install(args):
     if with_nvidia_kms:
         UbuntuDrivers.detect.set_nvidia_kms(1)
 
-    # --package-list should not install any packages
-    if args.package_list:
-        with open(args.package_list, 'a') as f:
-            f.write('\n'.join(to_install))
-            f.write('\n')
-            return 0
-
     ret = subprocess.call(['apt-get', 'install', '-o',
         'DPkg::options::=--force-confnew', '-y'] + to_install)
 
     oem_meta_to_install = fnmatch.filter(to_install, 'oem-*-meta')
 
-    # Abort if the installation failed
-    if ret != 0:
+    # create package list
+    if ret == 0 and args.package_list:
+        with open(args.package_list, 'a') as f:
+            f.write('\n'.join(to_install))
+            f.write('\n')
+    elif ret != 0:
         return ret
 
     for package_to_install in oem_meta_to_install:


### PR DESCRIPTION
This allows enabling KMS, and picking up the configuration which ubuntu-drivers is supposed to generate for the target chroot in ubiquity.