### PR TITLE
Fix a pycodestyle E721 error with the newer python

### DIFF
--- a/tests/testarchive.py
+++ b/tests/testarchive.py
@@ -125,7 +125,7 @@ Architecture: %s
                 f.write('%s: %s\n' % (k, v))
 
         for path, contents in files.items():
-            if type(contents) == bytes:
+            if isinstance(contents, bytes):
                 mode = 'wb'
             else:
                 mode = 'w'


### PR DESCRIPTION
In Noble

```
$ python3.12 -B tests/run test_static.TestStatic.test_pycodestyle_clean
test_pycodestyle_clean (test_static.TestStatic.test_pycodestyle_clean)
pycodestyle - Python style guide checker ... tests/testarchive.py:128:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
FAIL
```
