### PR TITLE
Replace "udevadm hwdb" with systemd-hwdb

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -507,10 +507,10 @@ def _get_db_name(syspath, alias):
     Values are None if unknown.
     '''
     try:
-        out = subprocess.check_output(['udevadm', 'hwdb', '--test=' + alias],
+        out = subprocess.check_output(['systemd-hwdb', 'query', alias],
                                       universal_newlines=True)
     except (OSError, subprocess.CalledProcessError) as e:
-        logging.debug('_get_db_name(%s, %s): udevadm hwdb failed: %s', syspath, alias, str(e))
+        logging.debug('_get_db_name(%s, %s): systemd-hwdb failed: %s', syspath, alias, str(e))
         return (None, None)
 
     logging.debug('_get_db_name: output\n%s\n', out)


### PR DESCRIPTION
udevadm hwdb is deprecated. Replace it with systemd-hwdb. Refer the upstream commit which output the message https://github.com/systemd/systemd/commit/f8717d2a723cf594617c3acb7e90992c881a3280

fix #94 