### PR TITLE
Ensure that self._major_ver is an int

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -48,7 +48,7 @@ class NvidiaPkgNameInfo(object):
         # Obsolete naming such as nvidia-340
         if match:
             self._obsolete_name_scheme = True
-            self._major_ver = match.group(1)
+            self._major_ver = int(match.group(1))
             self._flavour = self._major_ver
             self.is_valid = True
             return


### PR DESCRIPTION
Otherwise the comparison in line 1014 will fail:

````
$ sudo ubuntu-drivers autoinstall
udevadm hwdb is deprecated. Use systemd-hwdb instead.
Traceback (most recent call last):
  File "/usr/bin/ubuntu-drivers", line 519, in <module>
    greet()
  File "/usr/lib/python3/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/ubuntu-drivers", line 438, in autoinstall
    command_install(config)
  File "/usr/bin/ubuntu-drivers", line 187, in command_install
    UbuntuDrivers.detect.nvidia_desktop_pre_installation_hook(to_install)
  File "/usr/lib/python3/dist-packages/UbuntuDrivers/detect.py", line 1014, in nvidia_desktop_pre_installation_hook
    if nvidia_info.get_major_version() >= 470:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'str' and 'int'
````