### PR TITLE
share/hybrid: Change Makefile to respect CC and CFLAGS environment variables

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,8 +31,8 @@ Build-Depends: debhelper (>= 9.20160709),
  pycodestyle|pep8,
  pyflakes3,
 Standards-Version: 3.9.8
-Vcs-Git: git://github.com/tseliot/ubuntu-drivers-common.git
-Vcs-Browser: https://github.com/tseliot/ubuntu-drivers-common
+Vcs-Git: git://github.com/canonical/ubuntu-drivers-common.git
+Vcs-Browser: https://github.com/canonical/ubuntu-drivers-common
 X-Python3-Version: >= 3.2
 
 Package: ubuntu-drivers-common

--- a/share/hybrid/Makefile
+++ b/share/hybrid/Makefile
@@ -1,19 +1,14 @@
 #!/usr/bin/make -f
 
-PROGRAM = gpu-manager
-PROGRAM_FILES = gpu-manager.c
-CC = gcc
-CFLAGS =-g -Wall $(shell pkg-config --cflags libpci libdrm libkmod) -Ijson-parser json-parser/json.c
-LDFLAGS =$(shell pkg-config --libs libpci libdrm libkmod) -lm
+PROG = gpu-manager
+OBJ = gpu-manager.o json-parser/json.o
 
-all: build
+override CFLAGS += -Wall $(shell pkg-config --cflags libpci libdrm libkmod)
+override LDLIBS += $(shell pkg-config --libs libpci libdrm libkmod) -lm
 
-gpu-manager: gpu-manager.o
-	$(CC) $(CFLAGS) gpu-manager.o $(LDFLAGS) -o gpu-manager
+all: $(PROG)
 
-gpu-manager.o:
-	$(CC) $(CFLAGS) -c gpu-manager.c
+$(PROG): $(OBJ)
 
-build: gpu-manager
 clean:
-	@rm -f $(PROGRAM) $(PROGRAM).o json.o
+	rm -f $(PROG) $(OBJ)

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -63,7 +63,7 @@
 #include <libkmod.h>
 #include "xf86drm.h"
 #include "xf86drmMode.h"
-#include "json.h"
+#include "json-parser/json.h"
 
 static inline void freep(void *);
 static inline void fclosep(FILE **);


### PR DESCRIPTION
During the introduction of the new frame pointer policy in Ubuntu, it was noticed that the produced gpu-manager binary does not have frame pointer.

It seems like this is due to the Makefile hard-coding the compile flags.

This patch changes the Makefile to use CC and CFLAGS from the environment (and also simplifies it when implicit rules already do the right thing).