### PR TITLE
Recommend hwe-*-meta for non-oem hardware enablement meta packages

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -1180,7 +1180,7 @@ def auto_install_filter(packages, drivers_str=''):
     '''
     # any package which matches any of those globs will be accepted
     whitelist = ['bcmwl*', 'pvr-omap*', 'virtualbox-guest*', 'nvidia-*',
-                 'open-vm-tools*', 'oem-*-meta', 'broadcom-sta-dkms']
+                 'open-vm-tools*', 'hwe-*-meta', 'oem-*-meta', 'broadcom-sta-dkms']
 
     # If users specify a driver, use gpgpu_install_filter()
     if drivers_str:


### PR DESCRIPTION
The plan is to use this namespace for harware enablement meta packages that are not part of the official certification process. They must be recommended to have subiquity pick them up on installation.