### PR TITLE
Check nvidia kernel parameters before removing SimpleDRM

### DIFF
--- a/share/hybrid/71-u-d-c-gpu-detection.rules
+++ b/share/hybrid/71-u-d-c-gpu-detection.rules
@@ -2,13 +2,14 @@
 
 # Remove SimpleDRM device when nvidia-drm loads.
 # This normally happens automatically for DRM devices that also register
-# a framebuffer device, but that's not the case yet for the nvidia driver.
+# a framebuffer device, but that's not necessarily the case for the nvidia driver.
 ACTION=="add", KERNEL=="card0", SUBSYSTEM=="drm", DRIVERS=="simple-framebuffer", ENV{U_D_C_IS_SIMPLEDRM}="1", RUN+="/bin/touch /run/u-d-c-card0-is-simpledrm"
 ACTION=="remove", KERNEL=="card0", SUBSYSTEM=="drm", ENV{U_D_C_IS_SIMPLEDRM}=="1", RUN+="/bin/rm -f /run/u-d-c-card0-is-simpledrm"
 ACTION=="add", KERNEL=="card[0-9]*", SUBSYSTEM=="drm", DRIVERS=="nvidia", \
-    IMPORT{program}="/bin/sh -c 'echo U_D_C_MODESET=`cat /sys/module/nvidia_drm/parameters/modeset`'"
+    IMPORT{program}="/bin/sh -c 'echo U_D_C_MODESET=`cat /sys/module/nvidia_drm/parameters/modeset`'", \
+    IMPORT{program}="/bin/sh -c 'echo U_D_C_FBDEV=`cat /sys/module/nvidia_drm/parameters/fbdev`'"
 ACTION=="add", KERNEL=="card[0-9]*", SUBSYSTEM=="drm", DRIVERS=="nvidia", \
-    ENV{U_D_C_MODESET}=="Y", TEST=="/run/u-d-c-card0-is-simpledrm", RUN+="/bin/rm /dev/dri/card0"
+    ENV{U_D_C_MODESET}=="Y", ENV{U_D_C_FBDEV}!="Y", TEST=="/run/u-d-c-card0-is-simpledrm", RUN+="/bin/rm /dev/dri/card0"
 
 # Create a file with the card details for gpu-manager
 ACTION=="add", SUBSYSTEM=="drm", DEVPATH=="*/drm/card*", RUN+="/sbin/u-d-c-print-pci-ids"

--- a/share/hybrid/71-u-d-c-gpu-detection.rules
+++ b/share/hybrid/71-u-d-c-gpu-detection.rules
@@ -5,7 +5,10 @@
 # a framebuffer device, but that's not the case yet for the nvidia driver.
 ACTION=="add", KERNEL=="card0", SUBSYSTEM=="drm", DRIVERS=="simple-framebuffer", ENV{U_D_C_IS_SIMPLEDRM}="1", RUN+="/bin/touch /run/u-d-c-card0-is-simpledrm"
 ACTION=="remove", KERNEL=="card0", SUBSYSTEM=="drm", ENV{U_D_C_IS_SIMPLEDRM}=="1", RUN+="/bin/rm -f /run/u-d-c-card0-is-simpledrm"
-ACTION=="add", KERNEL=="card[0-9]*", SUBSYSTEM=="drm", DRIVERS=="nvidia", TEST=="/run/u-d-c-card0-is-simpledrm", RUN+="/bin/rm /dev/dri/card0"
+ACTION=="add", KERNEL=="card[0-9]*", SUBSYSTEM=="drm", DRIVERS=="nvidia", \
+    IMPORT{program}="/bin/sh -c 'echo U_D_C_MODESET=`cat /sys/module/nvidia_drm/parameters/modeset`'"
+ACTION=="add", KERNEL=="card[0-9]*", SUBSYSTEM=="drm", DRIVERS=="nvidia", \
+    ENV{U_D_C_MODESET}=="Y", TEST=="/run/u-d-c-card0-is-simpledrm", RUN+="/bin/rm /dev/dri/card0"
 
 # Create a file with the card details for gpu-manager
 ACTION=="add", SUBSYSTEM=="drm", DEVPATH=="*/drm/card*", RUN+="/sbin/u-d-c-print-pci-ids"


### PR DESCRIPTION
*  **Don't remove SimpleDRM if nvidia does not have modesetting** (UDENG-4409)
    With nvidia-drm.modeset=0 the driver still loads and registers a DRM device,
    but with all KMS capabilities disabled.
    If we were to remove SimpleDRM in that case, we would be removing the only
    functioning KMS driver on the system.


*  **Don't remove SimpleDRM if nvidia has fbdev**    
    When registering an fbdev the kernel will automatically unregister
    the SimpleDRM device.