### PR TITLE
Implement kernel version check at start of list or install

### DIFF
--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -20,6 +20,7 @@ import apt_pkg
 
 from functools import cmp_to_key
 import UbuntuDrivers.detect
+from UbuntuDrivers import kerneldetection
 
 sys_path = os.environ.get('UBUNTU_DRIVERS_SYS_DIR')
 
@@ -56,6 +57,15 @@ def command_list(args):
         print(ex)
         return 1
 
+
+    # First check if kernel needs updating
+    kernel_detector = kerneldetection.KernelDetection(cache)
+
+    should_exit = kernel_detector.get_kernel_update_warning(args.include_dkms)
+
+    if should_exit:
+        return 1
+
     packages = UbuntuDrivers.detect.system_driver_packages(apt_cache=cache,
         sys_path=sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta)
 
@@ -88,6 +98,15 @@ def command_list_oem(args):
     except Exception as ex:
         print(ex)
         return 1
+    
+
+    # First check if kernel needs updating
+    kernel_detector = kerneldetection.KernelDetection(cache)
+
+    should_exit = kernel_detector.get_kernel_update_warning(args.include_dkms)
+
+    if should_exit:
+        return 1
 
     packages = UbuntuDrivers.detect.system_device_specific_metapackages(
         apt_cache=cache, sys_path=sys_path, include_oem=args.install_oem_meta)
@@ -112,6 +131,15 @@ def list_gpgpu(args):
         cache = apt_pkg.Cache(None)
     except Exception as ex:
         print(ex)
+        return 1
+
+
+    # First check if kernel needs updating
+    kernel_detector = kerneldetection.KernelDetection(cache)
+
+    should_exit = kernel_detector.get_kernel_update_warning(args.include_dkms)
+
+    if should_exit:
         return 1
 
     packages = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache, sys_path)
@@ -172,6 +200,16 @@ def command_install(args):
 
     with_nvidia_kms = False
     is_nvidia = False
+
+
+    # First check if kernel needs updating
+    kernel_detector = kerneldetection.KernelDetection(cache)
+
+    should_exit = kernel_detector.get_kernel_update_warning(args.include_dkms)
+
+    if should_exit:
+        return 1
+
 
     to_install = UbuntuDrivers.detect.get_desktop_package_list(cache, sys_path,
         free_only=args.free_only, include_oem=args.install_oem_meta,
@@ -257,6 +295,15 @@ def install_gpgpu(args):
         cache = apt_pkg.Cache(None)
     except Exception as ex:
         print(ex)
+        return 1
+
+
+    # First check if kernel needs updating
+    kernel_detector = kerneldetection.KernelDetection(cache)
+
+    should_exit = kernel_detector.get_kernel_update_warning(args.include_dkms)
+
+    if should_exit:
         return 1
 
     packages = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache, sys_path)
@@ -470,6 +517,15 @@ def list(config, **kwargs):
         cache = apt_pkg.Cache(None)
     except Exception as ex:
         print(ex)
+        return 1
+
+
+    # First check if kernel needs updating
+    kernel_detector = kerneldetection.KernelDetection(cache)
+
+    should_exit = kernel_detector.get_kernel_update_warning(include_dkms)
+
+    if should_exit:
         return 1
 
     if kwargs.get('gpgpu'):


### PR DESCRIPTION
To ensure users are not running an outdated prebuilt kernel (which could cause compatibility issues if the recommended Nvidia drivers are only built for a more recent kernel version), and to ensure that the user is aware of the implications of the DKMS module usage if running a custom kernel for which DKMS modules would be required, add the following behavior to the "install" and "list" commands (and their variants):

- If the user is running a kernel version that is not provided by an Ubuntu kernel package, require them to pass --include-dkms to proceed (detected by matching `uname -r` output against Ubuntu version format, then checking to ensure Ubuntu kernel metapackage is installed)
- If the user is running an Ubuntu kernel, and any installed Ubuntu kernel metapackages have updates available according to the apt cache, warn them to upgrade before proceeding.

It is worth discussing whether we should eventually be more assertive about having the Ubuntu kernel up-to-date, but for now, it is only implemented as a warning.