### PR TITLE
Require root for install and autoinstall (LP: #1920225)

### DIFF
--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -459,6 +459,13 @@ def greet(config, gpgpu, free_only, package_list, no_oem, **kwargs):
 @pass_config
 def install(config, **kwargs):
     '''Install a driver [driver[:version][,driver[:version]]]'''
+
+    # Require root
+    if os.geteuid() != 0:
+        print("Error: 'ubuntu-drivers install' must be run as root. Try using 'sudo'.", file=sys.stderr)
+        sys.exit(1)
+
+
     if kwargs.get('gpgpu'):
         config.gpgpu = True
     if kwargs.get('free_only'):

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -488,6 +488,11 @@ def autoinstall(config, **kwargs):
     '''Deprecated, please use "install" instead'''
     #print('install, {0}'.format(kwargs['driver']))
 
+    # Require root
+    if os.geteuid() != 0:
+        print("Error: 'ubuntu-drivers autoinstall' must be run as root. Try using 'sudo'.", file=sys.stderr)
+        sys.exit(1)
+
     if kwargs.get('free_only'):
         config.free_only = True
     # if kwargs.get('package_list'):


### PR DESCRIPTION
I also run into the issue as seen in LP #1920225. It's an insufficient privileges issue when running autoinstall or install.

With 1:0.10.2:
```
conrad@thinkpad:~$ ubuntu-drivers install
Traceback (most recent call last):
  File "/usr/bin/ubuntu-drivers", line 597, in <module>
    greet()
  File "/usr/lib/python3/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/ubuntu-drivers", line 482, in install
    command_install(config)
  File "/usr/bin/ubuntu-drivers", line 228, in command_install
    UbuntuDrivers.detect.nvidia_desktop_pre_installation_hook(to_install)
  File "/usr/lib/python3/dist-packages/UbuntuDrivers/detect.py", line 1076, in nvidia_desktop_pre_installation_hook
    set_nvidia_kms(1)
  File "/usr/lib/python3/dist-packages/UbuntuDrivers/detect.py", line 585, in set_nvidia_kms
    kms_fd = open(nvidia_kms_file, 'w')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/lib/modprobe.d/nvidia-kms.conf'
```

```
conrad@thinkpad:~$ ubuntu-drivers autoinstall
Traceback (most recent call last):
  File "/usr/bin/ubuntu-drivers", line 592, in <module>
    greet()
  File "/usr/lib/python3/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/ubuntu-drivers", line 501, in autoinstall
    command_install(config)
  File "/usr/bin/ubuntu-drivers", line 228, in command_install
    UbuntuDrivers.detect.nvidia_desktop_pre_installation_hook(to_install)
  File "/usr/lib/python3/dist-packages/UbuntuDrivers/detect.py", line 1076, in nvidia_desktop_pre_installation_hook
    set_nvidia_kms(1)
  File "/usr/lib/python3/dist-packages/UbuntuDrivers/detect.py", line 585, in set_nvidia_kms
    kms_fd = open(nvidia_kms_file, 'w')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/lib/modprobe.d/nvidia-kms.conf'
```

With change:
```
conrad@thinkpad:~$ ubuntu-drivers install
Error: 'ubuntu-drivers install' must be run as root. Try using 'sudo'.
```
```
conrad@thinkpad:~$ ubuntu-drivers autoinstall
Error: 'ubuntu-drivers autoinstall' must be run as root. Try using 'sudo'.
```