### PR TITLE
Add more accurate help text for gpgpu flag

### DIFF
--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -385,7 +385,7 @@ def command_debug(args):
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.option('--gpgpu', is_flag=True, help='Install drivers for use in a headless (aka General Purpose GPU) environment. This results in a smaller installation footprint by not installing packages that are only useful in graphical environments.')
+@click.option('--gpgpu', is_flag=True, help='Install “general-purpose computing” drivers for use in a headless server environment. This installs a server (ERD) flavor of the driver (which is required for compatibility with some server applications, such as nvidia-fabricmanager), and also results in a smaller installation footprint by not installing packages that are only useful in graphical environments.')
 @click.option('--free-only', is_flag=True, help='Only consider free packages')
 @click.option('--package-list', nargs=1, metavar='PATH', help='Create file with list of installed packages (in install mode)')
 @click.option('--no-oem', is_flag=True, default=False, show_default=True, metavar='install_oem_meta', help='Do not include OEM enablement packages (these enable an external archive)')


### PR DESCRIPTION
The prior gpgpu help text does not capture the fact that the ERD/gpgpu variant of the driver is required for some server applications. We should make that more clear in the help text.