### PR TITLE
Consolidate GPGPU apt filtering functionality into detect.py

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -1014,54 +1014,12 @@ def get_desktop_package_list(
     packages = system_driver_packages(
         apt_cache, sys_path, freeonly=free_only,
         include_oem=include_oem)
-    packages = auto_install_filter(packages, driver_string, get_recommended=False)
-    if not packages:
-        logging.debug('No drivers found for installation.')
-        return packages
 
-    depcache = apt_pkg.DepCache(apt_cache)
-    records = apt_pkg.PackageRecords(apt_cache)
-
-    # ignore packages which are already installed
     to_install = []
-    for p, _ in sorted(packages.items(),
-                       key=cmp_to_key(lambda left, right: _cmp_gfx_alternatives(left[0], right[0])),
-                       reverse=True):
-        package_obj = apt_cache[p]
-        if not package_obj.current_ver:
-
-            candidate = depcache.get_candidate_ver(package_obj)
-            records.lookup(candidate.file_list[0])
-            to_install.append(p)
-
-            # See if runtimepm is supported
-            if records['runtimepm']:
-                # Create a file for nvidia-prime
-                try:
-                    pm_fd = open('/run/nvidia_runtimepm_supported', 'w')
-                    pm_fd.write('\n')
-                    pm_fd.close()
-                except PermissionError:
-                    # No need to error out here, since package
-                    # installation will fail
-                    pass
-            # Add the matching linux modules package when available
-            try:
-                modules_package = get_linux_modules_metapackage(apt_cache, p)
-                if modules_package and not apt_cache[modules_package].current_ver:
-                    if not include_dkms and "dkms" in modules_package:
-                        to_install.remove(p)
-                        continue
-                    to_install.append(modules_package)
-
-                    lrm_meta = get_userspace_lrm_meta(apt_cache, p)
-                    if lrm_meta and not apt_cache[lrm_meta].current_ver:
-                        # Add the lrm meta and drop the non lrm one
-                        to_install.append(lrm_meta)
-                        to_install.remove(p)
-                    break
-            except KeyError:
-                pass
+    to_install = auto_install_filter(apt_cache, include_dkms, packages, driver_string, get_recommended=False)
+    if not to_install:
+        logging.debug('No drivers found for installation.')
+        return to_install
 
     return to_install
 
@@ -1130,11 +1088,106 @@ def _process_driver_string(string):
     return driver
 
 
-def gpgpu_install_filter(packages, drivers_str, get_recommended=True):
+def already_installed_filter(cache, packages, include_dkms, comparator):
+    '''
+    Takes a list of packages of this format:
+    {'modalias': 'pci:v000010DEd000010C3sv00003842sd00002670bc03sc03i00',
+    'syspath': '/tmp/umockdev.8CRPA3/sys/devices/graphics', 'free': False,
+     'from_distro': False, 'support': None, 'open_preferred': False,
+     'vendor': 'NVIDIA Corporation', 'model': 'GT218 [GeForce 8400 GS Rev. 3]',
+     'metapackage': 'nvidia-headless-no-dkms-410', 'recommended': True}
+    checks to see if the requested packages are alreay installed, then filters
+    them out if so.
+
+    It returns a simplified list of just the package names for apt to install,
+    of the form:
+    ['nvidia-driver-410', 'nvidia-headless-no-dkms-410']
+    '''
+
+    # If there's no apt cache, there's no way to check what
+    # is already installed - so don't filter anything down.
+    if not cache:
+        return list(packages.keys())
+
+    depcache = apt_pkg.DepCache(cache)
+    to_install = []
+    for p, _ in sorted(packages.items(),
+                       key=cmp_to_key(lambda left, right:
+                                      comparator(left[0], right[0])),
+                       reverse=True):
+        if comparator == _cmp_gfx_alternatives:
+            candidate_ver = depcache.get_candidate_ver(cache[p])
+            records = apt_pkg.PackageRecords(cache)
+            records.lookup(candidate_ver.file_list[0])
+            # See if runtimepm is supported
+            if records['runtimepm']:
+                # Create a file for nvidia-prime
+                try:
+                    pm_fd = open('/run/nvidia_runtimepm_supported', 'w')
+                    pm_fd.write('\n')
+                    pm_fd.close()
+                except PermissionError:
+                    # No need to error out here, since package
+                    # installation will fail
+                    pass
+
+        candidate = packages[p].get('metapackage')
+
+        if candidate:
+            if cache[candidate].current_ver:
+                to_install = []
+                break
+            else:
+                to_install.append(p)
+                to_install.append(candidate)
+        else:
+            logging.debug("No candidate metapackage found for " + str(p))
+            to_install.append(p)
+
+        logging.debug("Candidate: " + str(candidate))
+        # Add the matching linux modules package
+        modules_package = get_linux_modules_metapackage(cache, p)
+        logging.debug(modules_package)
+        if modules_package and not cache[modules_package].current_ver:
+            if not include_dkms and "dkms" in modules_package:
+                if p in to_install:
+                    to_install.remove(p)
+                if candidate in to_install:
+                    to_install.remove(candidate)
+                continue
+            # Only remove the base package if using --gpgpu
+            # (since that is a headless install, whereas we want utils
+            #  on desktop)
+            if p in to_install and comparator == _cmp_gfx_alternatives_gpgpu:
+                to_install.remove(p)
+            to_install.append(modules_package)
+
+            lrm_meta = get_userspace_lrm_meta(cache, p)
+            if lrm_meta and not cache[lrm_meta].current_ver:
+                # Add the lrm meta and drop the non lrm one
+                to_install.append(lrm_meta)
+                if p in to_install and comparator == _cmp_gfx_alternatives_gpgpu:
+                    to_install.remove(p)
+            break
+
+    # Final filter
+    for p in sorted(to_install, reverse=True):
+        if cache and cache[p].current_ver:
+            logging.debug("Removing already-installed package from to_install: " + p)
+            to_install.remove(p)
+
+    logging.debug("to_install_final:  " + str(to_install))
+    return to_install
+
+
+def gpgpu_install_filter(cache, include_dkms, packages, drivers_str, get_recommended=True, comparator=None):
     drivers = []
     allow = []
     result = {}
-    '''Filter the Ubuntu packages according to the parameters the users passed
+    '''Filter the Ubuntu packages according to the parameters the users passed.
+
+    Returns a list of drivers to be installed, of the form
+    ['nvidia-driver-410', 'nvidia-headless-no-dkms-410']
 
     Ubuntu-drivers syntax
 
@@ -1154,7 +1207,10 @@ def gpgpu_install_filter(packages, drivers_str, get_recommended=True):
     ubuntu-drivers autoinstall --gpgpu amdgpu:version
     '''
     if not packages:
-        return result
+        return list(result.keys())
+
+    if not comparator:
+        comparator = _cmp_gfx_alternatives_gpgpu
 
     if drivers_str:
         # Just one driver
@@ -1173,7 +1229,7 @@ def gpgpu_install_filter(packages, drivers_str, get_recommended=True):
         drivers.append(driver)
 
     if len(drivers) < 1:
-        return result
+        return already_installed_filter(cache, result, include_dkms, comparator)
 
     # If the vendor is not specified, we assume it's nvidia
     it = 0
@@ -1190,7 +1246,7 @@ def gpgpu_install_filter(packages, drivers_str, get_recommended=True):
         if vendors_temp.__contains__(vendor):
             # TODO: raise error here
             logging.debug('Multiple nvidia versions passed at the same time')
-            return result
+            return already_installed_filter(cache, result, include_dkms, comparator)
         vendors_temp.append(vendor)
         it += 1
 
@@ -1230,14 +1286,14 @@ def gpgpu_install_filter(packages, drivers_str, get_recommended=True):
                         result[p] = packages[p]
                         # print('Found "recommended" flavour in %s' % (packages[p]))
                 break
-    return result
+    return already_installed_filter(cache, result, include_dkms, comparator)
 
 
-def auto_install_filter(packages, drivers_str='', get_recommended=True):
+def auto_install_filter(cache, include_dkms, packages, drivers_str='', get_recommended=True, comparator=None):
     '''Get packages which are appropriate for automatic installation.
 
     Return the subset of the given list of packages which are appropriate for
-    automatic installation by the installer. This applies to e. g. the Broadcom
+    automatic installation by the installer as a list. This applies to e. g. the Broadcom
     Wifi driver (as there is no alternative), but not to the FGLRX proprietary
     graphics driver (as the free driver works well and FGLRX does not provide
     KMS).
@@ -1246,9 +1302,13 @@ def auto_install_filter(packages, drivers_str='', get_recommended=True):
     whitelist = ['bcmwl*', 'pvr-omap*', 'virtualbox-guest*', 'nvidia-*',
                  'open-vm-tools*', 'hwe-*-meta', 'oem-*-meta', 'broadcom-sta-dkms']
 
+    # Use _cmp_gfx_alternatives as the default comparator, if none is specified
+    if not comparator:
+        comparator = _cmp_gfx_alternatives
+
     # If users specify a driver, use gpgpu_install_filter()
     if drivers_str:
-        results = gpgpu_install_filter(packages, drivers_str)
+        results = gpgpu_install_filter(cache, include_dkms, packages, drivers_str, True, comparator)
         return results
 
     allow = []
@@ -1262,7 +1322,7 @@ def auto_install_filter(packages, drivers_str='', get_recommended=True):
                 result[p] = packages[p]
         else:
             result[p] = packages[p]
-    return result
+    return already_installed_filter(cache, result, include_dkms, comparator)
 
 
 def detect_plugin_packages(apt_cache=None):

--- a/tests/test_ubuntu_drivers.py
+++ b/tests/test_ubuntu_drivers.py
@@ -566,9 +566,9 @@ class DetectTest(unittest.TestCase):
             chroot.remove()
 
         self.assertTrue('nvidia-driver-450' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
         # LTSB always wins on the server
-        self.assertEqual(set(packages), set(['nvidia-driver-450']))
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-450-generic-hwe-20.04']))
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
         # Get the linux-modules-nvidia module for the kernel
         # So we expect the DKMS package as a fallback
@@ -797,11 +797,10 @@ class DetectTest(unittest.TestCase):
                                                                                  'nvidia-driver-510')
         finally:
             chroot.remove()
-
         self.assertTrue('nvidia-driver-510' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
         # LTSB always wins on the server
-        self.assertEqual(set(packages), set(['nvidia-driver-510']))
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-510-generic-hwe-20.04']))
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
         # Get the linux-modules-nvidia module for the kernel
         # So we expect the DKMS package as a fallback
@@ -1005,20 +1004,23 @@ class DetectTest(unittest.TestCase):
                                dependencies={'Depends': 'linux-headers-5.4.0-25-generic'},
                                extra_tags={})
 
-            archive.create_deb('linux-generic-hwe-18.04',
-                               dependencies={'Depends': 'linux-generic'},
-                               extra_tags={'Source':
-                                           'linux-meta'})
-            archive.create_deb('linux-generic-hwe-18.04-edge',
-                               dependencies={'Depends': 'linux-generic'},
-                               extra_tags={'Source':
-                                           'linux-meta'})
-            archive.create_deb('linux-headers-generic-hwe-18.04',
-                               dependencies={'Depends': 'linux-headers-generic'},
-                               extra_tags={})
-            archive.create_deb('linux-headers-generic-hwe-18.04-edge',
-                               dependencies={'Depends': 'linux-headers-generic'},
-                               extra_tags={})
+            archive.create_deb(
+                                'linux-generic-hwe-18.04',
+                                dependencies={'Depends': 'linux-generic'},
+                                extra_tags={'Source':
+                                            'linux-meta'})
+            archive.create_deb(
+                                'linux-generic-hwe-18.04-edge',
+                                dependencies={'Depends': 'linux-generic'},
+                                extra_tags={'Source': 'linux-meta'})
+            archive.create_deb(
+                                'linux-headers-generic-hwe-18.04',
+                                dependencies={'Depends': 'linux-headers-generic'},
+                                extra_tags={})
+            archive.create_deb(
+                                'linux-headers-generic-hwe-18.04-edge',
+                                dependencies={'Depends': 'linux-headers-generic'},
+                                extra_tags={})
 
             chroot.add_repository(archive.path, True, False)
             apt_pkg.init_config()
@@ -1056,9 +1058,9 @@ class DetectTest(unittest.TestCase):
             chroot.remove()
 
         self.assertTrue('nvidia-driver-520' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
         # LTSB always wins on the server
-        self.assertEqual(set(packages), set(['nvidia-driver-520']))
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-520-generic-hwe-20.04']))
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
         # Get the linux-modules-nvidia module for the kernel
         # So we expect the DKMS package as a fallback
@@ -1454,31 +1456,31 @@ class DetectTest(unittest.TestCase):
             chroot.remove()
 
         self.assertTrue('nvidia-driver-510' in res_install_510)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_install_510, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-510']))
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res_install_510, 'nvidia')
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-510-generic-hwe-20.04']))
 
         self.assertTrue('nvidia-driver-470' in res_wrong_json)
         self.assertFalse('nvidia-driver-510' in res_wrong_json)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_wrong_json, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-470']))
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res_wrong_json, 'nvidia')
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-470-generic-hwe-20.04']))
 
         self.assertTrue('nvidia-driver-470' in res_470_no_390)
         self.assertTrue('nvidia-driver-390' in res_470_no_390)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_470_no_390, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-470']))
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res_470_no_390, 'nvidia')
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-470-generic-hwe-20.04']))
 
         self.assertTrue('nvidia-driver-470' in res_same_470)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_same_470, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-470']))
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res_same_470, 'nvidia')
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-470-generic-hwe-20.04']))
 
         self.assertTrue('nvidia-driver-470' in res_470_no_490)
         self.assertFalse('nvidia-driver-490' in res_470_no_490)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_470_no_490, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-470']))
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res_470_no_490, 'nvidia')
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-470-generic-hwe-20.04']))
 
         self.assertTrue('nvidia-driver-520' in res_520_only)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_520_only, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-520']))
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res_520_only, 'nvidia')
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-520-generic-hwe-20.04']))
 
     def test_system_driver_packages_chroot_core_lrm_1(self):
         '''system_driver_packages_chroot_core_lrm_1() -lrm vs -core'''
@@ -1712,6 +1714,7 @@ class DetectTest(unittest.TestCase):
             depcache = apt_pkg.DepCache(cache)
 
             target_name = 'nvidia-driver-535'
+            target_set = {'linux-modules-nvidia-535-generic-hwe-20.04', 'nvidia-driver-lrm-535'}
             # Install kernel packages
             for pkg in ('linux-image-5.4.0-25-generic',
                         'linux-image-5.4.0-24-generic',
@@ -1740,9 +1743,9 @@ class DetectTest(unittest.TestCase):
             chroot.remove()
 
         self.assertTrue(target_name in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
         # LTSB always wins on the server
-        self.assertEqual(set(packages), set([target_name]))
+        self.assertEqual(set(packages), target_set)
         lrm_meta = UbuntuDrivers.detect.get_userspace_lrm_meta(cache, target_name)
         self.assertEqual(lrm_meta, 'nvidia-driver-lrm-535')
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
@@ -1785,10 +1788,11 @@ class DetectTest(unittest.TestCase):
         finally:
             chroot.remove()
         self.assertTrue('nvidia-driver-410' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-410']))
-        driver = list(packages.keys())[0]
-        self.assertEqual(packages[driver].get('metapackage'), 'nvidia-headless-no-dkms-410')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
+        # Assertions have been changed to reflect that detect.already_installed_filter will provide the modules
+        # package and metapackage directly, in line with what ubuntu-drivers was doing previously without
+        # detect.py's awareness
+        self.assertEqual(set(packages), set(['nvidia-driver-410', 'nvidia-headless-no-dkms-410']))
 
     def test_system_gpgpu_driver_packages_chroot2(self):
         '''system_gpgpu_driver_packages() for test package repository'''
@@ -1924,10 +1928,11 @@ class DetectTest(unittest.TestCase):
             chroot.remove()
 
         self.assertTrue('nvidia-driver-410' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-410']))
-        driver = list(packages.keys())[0]
-        self.assertEqual(packages[driver].get('metapackage'), 'nvidia-headless-no-dkms-410')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
+        # Assertions have been changed to reflect that detect.already_installed_filter will provide the modules
+        # package and metapackage directly, in line with what ubuntu-drivers was doing previously without
+        # detect.py's awareness
+        self.assertEqual(set(packages), set(['nvidia-dkms-410', 'nvidia-headless-no-dkms-410']))
         self.assertEqual(linux_package, 'linux-generic-hwe-18.04')
         # No linux-modules-nvidia module is available for the kernel
         # So we expect the DKMS package as a fallback
@@ -2062,11 +2067,12 @@ class DetectTest(unittest.TestCase):
         finally:
             chroot.remove()
 
+        # Assertions have been changed to reflect that detect.already_installed_filter will provide the modules
+        # package and metapackage directly, in line with what ubuntu-drivers was doing previously without detect.py's
+        # awareness
         self.assertTrue('nvidia-driver-410' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-410']))
-        driver = list(packages.keys())[0]
-        self.assertEqual(packages[driver].get('metapackage'), 'nvidia-headless-no-dkms-410')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
+        self.assertEqual(set(packages), set(['nvidia-headless-no-dkms-410', 'linux-modules-nvidia-410-generic']))
         self.assertEqual(linux_package, 'linux-generic')
         # Get the linux-modules-nvidia module for the kernel
         # So we expect the DKMS package as a fallback
@@ -2249,11 +2255,13 @@ class DetectTest(unittest.TestCase):
         finally:
             chroot.remove()
 
+        # Assertions have been changed to reflect that detect.already_installed_filter will provide the modules
+        # package and metapackage directly, in line with what ubuntu-drivers was doing previously without detect.py's
+        # awareness
         self.assertTrue('nvidia-driver-440' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-440']))
-        driver = list(packages.keys())[0]
-        self.assertEqual(packages[driver].get('metapackage'), 'nvidia-headless-no-dkms-440')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
+        self.assertEqual(set(packages), set(['nvidia-headless-no-dkms-440',
+                                             'linux-modules-nvidia-440-generic-hwe-20.04']))
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
         # Get the linux-modules-nvidia module for the kernel
         # So we expect the DKMS package as a fallback
@@ -2642,11 +2650,10 @@ class DetectTest(unittest.TestCase):
             chroot.remove()
 
         self.assertTrue('nvidia-driver-418-server' in res)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res, 'nvidia')
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(cache, True, res, 'nvidia')
         # LTSB always wins on the server
-        self.assertEqual(set(packages), set(['nvidia-driver-418-server']))
-        driver = list(packages.keys())[0]
-        self.assertEqual(packages[driver].get('metapackage'), 'nvidia-headless-no-dkms-418-server')
+        self.assertEqual(set(packages), set(['nvidia-headless-no-dkms-418-server',
+                                             'linux-modules-nvidia-418-server-generic-hwe-20.04']))
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
         # Get the linux-modules-nvidia module for the kernel
         # So we expect the DKMS package as a fallback
@@ -2957,7 +2964,7 @@ class DetectTest(unittest.TestCase):
             res = UbuntuDrivers.detect.system_driver_packages(cache,
                                                               sys_path=self.umockdev.get_sys_dir())
             linux_package = UbuntuDrivers.detect.get_linux(cache)
-            packages = UbuntuDrivers.detect.auto_install_filter(res, 'nvidia')
+            packages = UbuntuDrivers.detect.auto_install_filter(cache, True, res, 'nvidia')
 
             modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(cache,
                                                                                  'nvidia-driver-515')
@@ -2968,7 +2975,7 @@ class DetectTest(unittest.TestCase):
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
 
         # PB always wins against NFB. Non-open wins against -open
-        self.assertEqual(set(packages), set(['nvidia-driver-515']))
+        self.assertEqual(set(packages), set(['nvidia-driver-515', 'linux-modules-nvidia-515-generic-hwe-20.04']))
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
         # Get the linux-modules-nvidia module for the kernel
         self.assertEqual(modules_package, 'linux-modules-nvidia-515-generic-hwe-20.04')
@@ -3289,7 +3296,7 @@ class DetectTest(unittest.TestCase):
             res = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache,
                                                                     sys_path=self.umockdev.get_sys_dir())
             linux_package = UbuntuDrivers.detect.get_linux(cache)
-            packages = UbuntuDrivers.detect.auto_install_filter(res, 'nvidia')
+            packages = UbuntuDrivers.detect.auto_install_filter(cache, True, res, 'nvidia')
 
             modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(cache,
                                                                                  'nvidia-driver-525-server')
@@ -3300,7 +3307,8 @@ class DetectTest(unittest.TestCase):
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
 
         # PB always wins against NFB. Non-open wins against -open
-        self.assertEqual(set(packages), set(['nvidia-driver-525-server']))
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-525-server-generic-hwe-20.04',
+                                             'nvidia-headless-no-dkms-525-server', 'nvidia-driver-525-server']))
         self.assertEqual(linux_package, 'linux-generic-hwe-20.04')
         # Get the linux-modules-nvidia module for the kernel
         self.assertEqual(modules_package, 'linux-modules-nvidia-525-server-generic-hwe-20.04')
@@ -3515,7 +3523,7 @@ class DetectTest(unittest.TestCase):
 
             res = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache,
                                                                     sys_path=self.umockdev.get_sys_dir())
-            packages = UbuntuDrivers.detect.auto_install_filter(res, 'nvidia')
+            packages = UbuntuDrivers.detect.auto_install_filter(cache, True, res, 'nvidia')
 
             modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(cache,
                                                                                  'nvidia-driver-560-server-open')
@@ -3524,7 +3532,9 @@ class DetectTest(unittest.TestCase):
 
         self.assertTrue('nvidia-driver-560-server-open' in res)
 
-        self.assertEqual(set(packages), set(['nvidia-driver-560-server-open']))
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-560-server-open-generic-hwe-20.04',
+                                             'nvidia-headless-no-dkms-560-server-open',
+                                             'nvidia-driver-560-server-open']))
         # Get the linux-modules-nvidia module for the kernel
         self.assertEqual(modules_package, 'linux-modules-nvidia-560-server-open-generic-hwe-20.04')
 
@@ -3777,7 +3787,7 @@ class DetectTest(unittest.TestCase):
 
             res = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache,
                                                                     sys_path=self.umockdev.get_sys_dir())
-            packages = UbuntuDrivers.detect.auto_install_filter(res, 'nvidia')
+            packages = UbuntuDrivers.detect.auto_install_filter(cache, True, res, 'nvidia')
 
             modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(cache,
                                                                                  'nvidia-driver-550-server')
@@ -3787,7 +3797,8 @@ class DetectTest(unittest.TestCase):
         self.assertTrue('nvidia-driver-550-server' in res)
 
         # PB always wins against NFB. open wins against non-open
-        self.assertEqual(set(packages), set(['nvidia-driver-550-server']))
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-550-server-generic-hwe-20.04',
+                                             'nvidia-headless-no-dkms-550-server', 'nvidia-driver-550-server']))
         # Get the linux-modules-nvidia module for the kernel
         self.assertEqual(modules_package, 'linux-modules-nvidia-550-server-generic-hwe-20.04')
 
@@ -3963,7 +3974,7 @@ class DetectTest(unittest.TestCase):
 
             res = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache,
                                                                     sys_path=self.umockdev.get_sys_dir())
-            packages = UbuntuDrivers.detect.auto_install_filter(res, 'nvidia')
+            packages = UbuntuDrivers.detect.auto_install_filter(cache, True, res, 'nvidia')
 
             modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(cache,
                                                                                  'nvidia-driver-550-server-open')
@@ -3973,7 +3984,9 @@ class DetectTest(unittest.TestCase):
         self.assertTrue('nvidia-driver-550-server-open' in res)
 
         # PB always wins against NFB. open wins against non-open
-        self.assertEqual(set(packages), set(['nvidia-driver-550-server-open']))
+        self.assertEqual(set(packages), set(['linux-modules-nvidia-550-server-open-generic-hwe-20.04',
+                                             'nvidia-headless-no-dkms-550-server-open',
+                                             'nvidia-driver-550-server-open']))
         # Get the linux-modules-nvidia module for the kernel
         self.assertEqual(modules_package, 'linux-modules-nvidia-550-server-open-generic-hwe-20.04')
 
@@ -4186,7 +4199,7 @@ class DetectTest(unittest.TestCase):
 
             res = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache,
                                                                     sys_path=self.umockdev.get_sys_dir())
-            packages = UbuntuDrivers.detect.auto_install_filter(res, 'nvidia')
+            packages = UbuntuDrivers.detect.auto_install_filter(cache, True, res, 'nvidia')
 
             modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(cache,
                                                                                  'nvidia-driver-550-server')
@@ -4195,7 +4208,8 @@ class DetectTest(unittest.TestCase):
 
         self.assertTrue('nvidia-driver-550-server' in res)
 
-        self.assertEqual(set(packages), set(['nvidia-driver-550-server']))
+        self.assertEqual(set(packages), set(['nvidia-headless-no-dkms-550-server',
+                                             'linux-modules-nvidia-550-server-generic', 'nvidia-driver-550-server']))
         # Get the linux-modules-nvidia module for the kernel
         self.assertEqual(modules_package, 'linux-modules-nvidia-550-server-generic')
 
@@ -4383,7 +4397,7 @@ exec /sbin/modinfo "$@"
     def test_auto_install_filter(self):
         '''auto_install_filter()'''
 
-        self.assertEqual(UbuntuDrivers.detect.auto_install_filter({}), {})
+        self.assertEqual(UbuntuDrivers.detect.auto_install_filter(None, True, {}), [])
 
         pkgs = {'bcmwl-kernel-source': {},
                 'nvidia-driver-xxx': {},
@@ -4391,21 +4405,20 @@ exec /sbin/modinfo "$@"
                 'pvr-omap4-egl': {}}
 
         self.assertEqual(
-            set(UbuntuDrivers.detect.auto_install_filter(pkgs)),
+            set(UbuntuDrivers.detect.auto_install_filter(None, True, pkgs)),
             set(['bcmwl-kernel-source', 'pvr-omap4-egl', 'nvidia-driver-xxx']))
 
         # should not include non-recommended variants
         pkgs = {'bcmwl-kernel-source': {},
                 'nvidia-driver-xxx': {'recommended': False},
                 'nvidia-173': {'recommended': True}}
-        self.assertEqual(set(UbuntuDrivers.detect.auto_install_filter(pkgs)),
+        self.assertEqual(set(UbuntuDrivers.detect.auto_install_filter(None, True, pkgs)),
                          set(['bcmwl-kernel-source', 'nvidia-173']))
 
     def test_gpgpu_install_filter(self):
         '''gpgpu_install_filter()'''
-
         # gpgpu driver[:version][,driver[:version]]
-        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter({}, 'nvidia'), {})
+        self.assertEqual(set(UbuntuDrivers.detect.gpgpu_install_filter(None, True, {}, 'nvidia')), set([]))
 
         pkgs = {'nvidia-driver-390': {'recommended': True},
                 'nvidia-driver-410': {},
@@ -4413,33 +4426,33 @@ exec /sbin/modinfo "$@"
 
         # Nothing is specified, we return the recommended driver
         self.assertEqual(
-            set(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, 'nvidia')),
+            set(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, 'nvidia')),
             set(['nvidia-driver-390']))
 
         # We specify that we want nvidia 410
         pkgs = {'nvidia-driver-390': {'recommended': True},
                 'nvidia-driver-410': {},
                 'nvidia-driver-340': {'recommended': False}}
-        self.assertEqual(set(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, '410')),
+        self.assertEqual(set(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, '410')),
                          set(['nvidia-driver-410']))
 
-        self.assertEqual(set(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, 'nvidia:410')),
+        self.assertEqual(set(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, 'nvidia:410')),
                          set(['nvidia-driver-410']))
 
         # Now with multiple drivers (to be implemented in the future)
-        self.assertEqual(set(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, 'nvidia:410,amdgpu:284')),
+        self.assertEqual(set(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, 'nvidia:410,amdgpu:284')),
                          set(['nvidia-driver-410']))
 
         # Specify the same nvidia driver twice, just to break things
-        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, 'nvidia:410,nvidia:390'),
-                         {})
+        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, 'nvidia:410,nvidia:390'),
+                         [])
 
         # More incorrect values
-        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, 'nv:410'), {})
+        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, 'nv:410'), [])
 
-        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, ':410'), {})
+        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, ':410'), [])
 
-        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(pkgs, 'nvidia-driver:410'), {})
+        self.assertEqual(UbuntuDrivers.detect.gpgpu_install_filter(None, True, pkgs, 'nvidia-driver:410'), [])
 
     def test_system_driver_packages_freeonly(self):
         '''system_driver_packages() returns only free packages'''

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -256,45 +256,10 @@ def install_gpgpu(args):
         return 1
 
     packages = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache, sys_path)
-    packages = UbuntuDrivers.detect.gpgpu_install_filter(packages, args.driver_string, get_recommended=False)
-    if not packages:
+    to_install = UbuntuDrivers.detect.gpgpu_install_filter(cache, args.include_dkms, packages, args.driver_string, get_recommended=False)
+    if not to_install:
         print('No drivers found for installation.')
         return not_found_exit_status
-
-    # ignore packages which are already installed
-    to_install = []
-    for p, _ in sorted(packages.items(),
-                       key=cmp_to_key(lambda left, right:
-                                      UbuntuDrivers.detect._cmp_gfx_alternatives_gpgpu(left[0], right[0])),
-                       reverse=True):
-        candidate = packages[p].get('metapackage')
-        if candidate:
-            if cache[candidate].current_ver:
-                to_install = []
-                break
-            else:
-                to_install.append(p)
-                to_install.append(candidate)
-        print(candidate)
-
-        if candidate:
-            # Add the matching linux modules package
-            modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(cache, p)
-            print(modules_package)
-            if modules_package and not cache[modules_package].current_ver:
-                if not args.include_dkms and "dkms" in modules_package:
-                    to_install.remove(p)
-                    to_install.remove(candidate)
-                    continue
-                to_install.remove(p)
-                to_install.append(modules_package)
-
-                lrm_meta = UbuntuDrivers.detect.get_userspace_lrm_meta(cache, p)
-                if lrm_meta and not cache[lrm_meta].current_ver:
-                    # Add the lrm meta and drop the non lrm one
-                    to_install.append(lrm_meta)
-                    to_install.remove(p)
-                break
 
     if not to_install:
         print('All the available drivers are already installed.')
@@ -332,7 +297,7 @@ def command_debug(args):
     depcache = apt_pkg.DepCache(cache)
     packages = UbuntuDrivers.detect.system_driver_packages(
         cache, sys_path, freeonly=args.free_only, include_oem=args.install_oem_meta)
-    auto_packages = UbuntuDrivers.detect.auto_install_filter(packages)
+    auto_packages = UbuntuDrivers.detect.auto_install_filter(cache, args.include_dkms, packages)
 
     print('=== modaliases in the system ===')
     for alias in aliases:


### PR DESCRIPTION
Prior to this change, the gpgpu driver installation procedure performs additional filtering of package candidates in ./ubuntu-drivers, which the test cases (which intend to test for
 end-user package filtering expectations) and any other direct
callers of detect.py's filter functions are unaware of.

This change moves all filtering logic to detect.py and adjusts all associated test cases as needed to represent the actual view of which drivers the end-user will have installed.

Direct invocation of auto install filter also includes nvidia-driver-XXX in tests now