### PR TITLE
Fix exit code for 'install --gpgpu' when no drivers found

### DIFF
--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -177,9 +177,12 @@ def command_install(args):
         free_only=args.free_only, include_oem=args.install_oem_meta,
         driver_string=args.driver_string, include_dkms=args.include_dkms)
 
-    if not to_install:
+    if to_install is None:
+        print('No drivers found for installation.')
+        return 1
+    elif not to_install:
         print('All the available drivers are already installed.')
-        return
+        return 0
 
     for package in to_install:
         if 'nvidia' in package:
@@ -242,9 +245,11 @@ def install_gpgpu(args):
         # Or Multiple drivers
         # e.g. --gpgpu nvidia:390,amdgpu
         not_found_exit_status = 1
+        
     else:
         # No args, just --gpgpu
-        not_found_exit_status = 0
+        not_found_exit_status = 1
+        
 
     apt_pkg.init_config()
     apt_pkg.init_system()
@@ -257,10 +262,10 @@ def install_gpgpu(args):
 
     packages = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache, sys_path)
     packages = UbuntuDrivers.detect.gpgpu_install_filter(packages, args.driver_string, get_recommended=False)
+   
     if not packages:
         print('No drivers found for installation.')
         return not_found_exit_status
-
     # ignore packages which are already installed
     to_install = []
     for p, _ in sorted(packages.items(),
@@ -298,7 +303,7 @@ def install_gpgpu(args):
 
     if not to_install:
         print('All the available drivers are already installed.')
-        return 0
+        return not_found_exit_status
 
     ret = subprocess.call(['apt-get', 'install', '-o',
         'DPkg::options::=--force-confnew',
@@ -437,9 +442,9 @@ def install(config, **kwargs):
         config.driver_string = ''.join(kwargs.get('driver'))
 
     if config.gpgpu:
-        install_gpgpu(config)
+        sys.exit(install_gpgpu(config))
     else:
-        command_install(config)
+        sys.exit(command_install(config))
 
 
 @greet.command()


### PR DESCRIPTION
Fix `ubuntu-drivers install --gpgpu` to return exit code 1 instead of 0 when no drivers are found. This allows scripts to properly detect installation failures.

Fixes #106