### PR TITLE
changelog: update plucky version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-drivers-common (1:0.10.2ubuntu0.1) plucky; urgency=medium
+ubuntu-drivers-common (1:0.10.2.1) plucky; urgency=medium
 
   * Clarify gpgpu flag help text (LP: #2115537)
 


### PR DESCRIPTION
1:0.10.2ubuntu0.1 was rejected for SRU, the correct version for ubuntu native packages should be 1:0.10.2.1:
```
 ubuntu-drivers-common | 1:0.9.7.6ubuntu3    | noble             | source
 ubuntu-drivers-common | 1:0.9.7.6ubuntu3.2  | noble-updates     | source
 ubuntu-drivers-common | 1:0.10.2            | plucky            | source
 ubuntu-drivers-common | 1:0.10.2ubuntu0.1   | plucky-rejected   | source
 ubuntu-drivers-common | 1:0.10.2.1          | plucky-unapproved | source (*)
 ubuntu-drivers-common | 1:0.10.3            | questing          | source

(*) this change
```
Noble has the same mistake, let's just leave it, but have plucky and later use the correct versioning.