### PR TITLE
Only list the target driver for custom configuration

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -319,9 +319,12 @@ def packages_for_modalias(apt_cache, modalias, modalias_map=None):
         if nvamd is not None and not found:
             logging.debug('%s is not in the package pool.' % nvamdn)
 
-    if not found:
-        if pat is None or not pat.match(modalias):
-            return []
+    if found:
+        logging.info('Found custom %s in the package pool.' % nvamdn)
+        return [apt_cache[nvamdn]]
+
+    if pat is None or not pat.match(modalias):
+        return []
 
     for alias in bus_map:
         if fnmatch.fnmatchcase(modalias.lower(), alias.lower()):
@@ -452,12 +455,10 @@ def _is_nv_allowing_runtimepm_supported(alias, ver):
                 gpus = list(json.load(stream)['chips'])
                 for gpu in gpus:
                     if gpu['devid'] == did and 'runtimepm' in gpu['features']:
-                        if gpu['branch'].split('.')[0] != ver:
-                            logging.debug('Candidate version does not match %s != %s' %
-                                          (gpu['branch'].split('.')[0], ver))
-                            return False
-                        logging.info("Found runtimepm supports on %s." % did)
-                        return True
+                        if ver in gpu['branch'].split('.')[0]:
+                            logging.info("Found runtimepm supports on %s." % did)
+                            return True
+                logging.debug('%s has no matched driver to support runtimepm' % did)
             except Exception:
                 logging.debug('_is_nv_allowing_runtimepm_supported(): unexpected json detected')
                 pass

--- a/tests/test_ubuntu_drivers.py
+++ b/tests/test_ubuntu_drivers.py
@@ -1381,7 +1381,7 @@ class DetectTest(unittest.TestCase):
    }
  ]
 }''')
-            res_470_no_390 = UbuntuDrivers.detect.system_driver_packages(cache,
+            res_390_no_470 = UbuntuDrivers.detect.system_driver_packages(cache,
                                                                          sys_path=self.umockdev.get_sys_dir())
 
             # point to the same version as candidate.
@@ -1462,10 +1462,10 @@ class DetectTest(unittest.TestCase):
         packages = UbuntuDrivers.detect.gpgpu_install_filter(res_wrong_json, 'nvidia')
         self.assertEqual(set(packages), set(['nvidia-driver-470']))
 
-        self.assertTrue('nvidia-driver-470' in res_470_no_390)
-        self.assertTrue('nvidia-driver-390' in res_470_no_390)
-        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_470_no_390, 'nvidia')
-        self.assertEqual(set(packages), set(['nvidia-driver-470']))
+        self.assertFalse('nvidia-driver-470' in res_390_no_470)
+        self.assertTrue('nvidia-driver-390' in res_390_no_470)
+        packages = UbuntuDrivers.detect.gpgpu_install_filter(res_390_no_470, 'nvidia')
+        self.assertEqual(set(packages), set(['nvidia-driver-390']))
 
         self.assertTrue('nvidia-driver-470' in res_same_470)
         packages = UbuntuDrivers.detect.gpgpu_install_filter(res_same_470, 'nvidia')


### PR DESCRIPTION
Respect the custom configuration if the NV driver series is specified. Fix runtimepm feature obtain if -open is specified in the branch field.

The selecting driver algorithm will prioritize LTSB over PB and NFB even though a custom configuration was set like series 570 or 575. The ubuntu-drivers will only list the series specified in the custom_supported_gpu.json according to  user's configuration.

Ex:
On machine with Nvidia dGPU device id [10de:2db8]

custom_supported_gpus.json
{
    "chips": [
       {
          "devid": "0x2DB8",
          "name": "NVIDIA RTX PRO 1000 Blackwell Generation Laptop GPU",
          "branch": "570-open",
          "features": [
            "dpycbcr420",
            "dpgsynccompatible",
            "hdmi4k60rgb444",
            "hdmigsynccompatible",
            "runtimepm",
            "vdpaufeaturesetK",
            "kernelopen"
          ]
      }
    ]
}

Without the change, it will list all supported drivers, and the driver with higher priority will be installed.
$ ubuntu-drivers list
nvidia-driver-580-open, (kernel modules provided by linux-modules-nvidia-580-open-oem-24.04c)
nvidia-driver-570-open, (kernel modules provided by linux-modules-nvidia-570-open-oem-24.04c)
nvidia-driver-580, (kernel modules provided by linux-modules-nvidia-580-oem-24.04c)
nvidia-driver-570, (kernel modules provided by linux-modules-nvidia-570-oem-24.04c)

With the change, it will list the target driver only, and user will install specified driver. 
$ ubuntu-drivers list
nvidia-driver-570-open, (kernel modules provided by linux-modules-nvidia-570-open-oem-24.04c)
