### PR TITLE
Prevent attempts to coinstall conflicting nvidia-driver-* packages (LP: #2125156)

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -1032,6 +1032,12 @@ def get_desktop_package_list(
 
             candidate = depcache.get_candidate_ver(package_obj)
             records.lookup(candidate.file_list[0])
+
+            # Do not add more than one nvidia-driver-* (or associated packages) to to_install
+            if p.startswith("nvidia-driver-"):
+                if any(pkg.startswith("nvidia-driver-") for pkg in to_install):
+                    continue
+
             to_install.append(p)
 
             # See if runtimepm is supported

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -267,6 +267,11 @@ def install_gpgpu(args):
                        key=cmp_to_key(lambda left, right:
                                       UbuntuDrivers.detect._cmp_gfx_alternatives_gpgpu(left[0], right[0])),
                        reverse=True):
+        # Do not add more than one nvidia-driver-* (or associated packages) to to_install
+        if p.startswith("nvidia-driver-"):
+            if any(pkg.startswith("nvidia-driver-") for pkg in to_install):
+                continue
+
         candidate = packages[p].get('metapackage')
         if candidate:
             if cache[candidate].current_ver:


### PR DESCRIPTION
Attempting to run `sudo ubuntu-drivers install` or `sudo ubuntu-drivers install --gpgpu` on some machines that support multiple Nvidia driver version branches can sometimes result in the generated `apt install` command including multiple conflicting packages, which causes the installation to be stopped.

Since only one package matching the `nvidia-driver-*` glob pattern should be installable in a valid solution, adjust the filtering logic to remove any `nvidia-driver-*` recommendations after the first.