### PR TITLE
Refactor: simplify devices path assignment

### DIFF
--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -113,7 +113,7 @@ def system_modaliases(sys_path=None):
     Return a modalias → sysfs path map.
     '''
     aliases = {}
-    devices = sys_path and '%s/devices' % (sys_path) or '/sys/devices'
+    devices = f"{sys_path}/devices" if sys_path else "/sys/devices"
     for path, dirs, files in os.walk(devices):
         modalias = None
 


### PR DESCRIPTION
Replaced the old "sys_path and ... or ..." expression with a more  readable conditional f-string. This makes the code easier to  understand and avoids relying on the implicit truthiness of sys_path.