### PR TITLE
Add build test CI job

### DIFF
--- a/.github/workflows/build-and-test-package.yaml
+++ b/.github/workflows/build-and-test-package.yaml
@@ -1,0 +1,35 @@
+name: Debian Package Build
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04 
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Enable deb-src in sources.list
+        # Append 'deb-src' entries to the sources list for fetching build dependencies
+        run: |
+          sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          cat /etc/apt/sources.list.d/ubuntu.sources
+
+      - name: Update package lists and install basic tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential debhelper fakeroot apt
+
+      - name: Install Build Dependencies for ubuntu-drivers-common
+        run: sudo apt build-dep -y ubuntu-drivers-common
+
+      - name: Run dpkg-buildpackage
+        # This step will fail the job if the build or test stages fail.
+        run: dpkg-buildpackage -us -uc -rfakeroot -b


### PR DESCRIPTION
Add a CI job as a quality-of-life feature for developers and reviewers, so that they can easily see if the functional tests in the package build steps fail when they submit a PR.