### PR TITLE
Allow to enable logs at runtime

### DIFF
--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -29,7 +29,7 @@ if not os.environ.get('PATH'):
     os.environ['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin'
 
 logger = logging.getLogger()
-LOGLEVEL = os.environ.get('LOGLEVEL', 'WARNING').upper()
+LOGLEVEL = os.environ.get('LOGLEVEL', logging.WARNING)
 logger.setLevel(level=LOGLEVEL)
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])


### PR DESCRIPTION
If it makes sense to do it like this?

To enable 
```
sudo LOGLEVEL=DEBUG ./ubuntu-drivers install
```