### PR TITLE
Add dbus interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,41 @@ The three main functions are:
 These functions only use python-apt. They do not need any other dependencies,
 root privileges, D-BUS calls, etc.
 
+## D-Bus API
+
+This project also provides a session-bus D-Bus service that exposes driver
+information. The service registers as `org.ubuntu.Drivers` on the session bus
+with the object path `/org/ubuntu/Drivers` and exposes a single method:
+
+* `drivers`: Returns a list of devices and their available drivers. The first
+  driver entry in each list is the recommended one.
+
+The returned structure is a list of dictionaries like:
+
+```python
+[
+   {
+      "sys_path": "/sys/devices/...",
+      "modalias": "pci:...",
+      "vendor": "NVIDIA Corporation",
+      "model": "GP107M [GeForce GTX 1050 Mobile]",
+      "drivers": [
+         {
+            "name": "nvidia-driver-570",
+            "source": "distro",
+            "free": False,
+            "builtin": False,
+         },
+         ...
+      ],
+   },
+   ...
+]
+```
+
+The D-Bus service implementation lives in `service/drivers_service.py` and is
+designed to exit after a short period of inactivity.
+
 ## Detection logic
 
 The principal method of mapping hardware to driver packages is to use modalias
@@ -109,7 +144,7 @@ For the autopkgtest of ubuntu-drivers, the following command can be used when
 developing test cases:
 
 ```shell
-$ PYTHONPATH=. tests/run test_ubuntu_drivers
+PYTHONPATH=. tests/run test_ubuntu_drivers
 ```
 
 Testing in a clean environment is always recommended. Using a pbuilder chroot,

--- a/UbuntuDrivers/service/drivers_service.py
+++ b/UbuntuDrivers/service/drivers_service.py
@@ -49,9 +49,11 @@ def build_drivers_payload() -> List[Dict[str, Any]]:
             drivers_list.append(
                 {
                     "name": pkg_name,
-                    "source": "distro"
-                    if pkg_info.get("from_distro", False)
-                    else "third-party",
+                    "source": (
+                        "distro"
+                        if pkg_info.get("from_distro", False)
+                        else "third-party"
+                    ),
                     "free": bool(pkg_info.get("free", False)),
                     "builtin": bool(pkg_info.get("builtin", False)),
                 }
@@ -130,7 +132,7 @@ class DriversService(dbus.service.Object):
         return True
 
     @dbus.service.method(BUS_NAME, in_signature="", out_signature="aa{sv}")
-    def drivers(self) -> List[Dict[str, Any]]:
+    def drivers(self) -> dbus.Array:
         """Return the list of devices and their available drivers."""
 
         self._touch()
@@ -142,7 +144,7 @@ def main() -> None:
 
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     bus = dbus.SessionBus()
-    dbus.service.BusName(DriversService.BUS_NAME, bus)
+    bus.request_name(DriversService.BUS_NAME)
 
     loop = GLib.MainLoop()
     DriversService(bus, mainloop=loop)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-drivers-common (1:0.10.8) resolute; urgency=medium
+
+  * Add D-Bus service for Ubuntu Drivers
+
+ -- Jean-Baptiste Lallement <jean-baptiste.lallement@canonical.com>  Thu, 26 Feb 2026 08:50:42 +0100
+
 ubuntu-drivers-common (1:0.10.7) resolute; urgency=medium
 
   * Remove mokutil requirement for s390x

--- a/debian/control
+++ b/debian/control
@@ -47,6 +47,10 @@ Depends: ${python3:Depends},
  python3-apt,
  python3-xkit,
  python3-click,
+ python3-dbus,
+ python3-gi,
+ gir1.2-glib-2.0,
+ dbus,
  udev,
  pciutils,
  usbutils,
@@ -58,6 +62,9 @@ Description: Detect and install additional Ubuntu driver packages
  .
   - a Python API for detecting driver packages for a particular piece of
     hardware or the whole system.
+ .
+  - a D-Bus service (org.ubuntu.Drivers) for querying driver information
+    via the session bus.
  .
   - an "ubuntu-drivers" command line tool to list or install driver packages
     (mostly for integration in installers).

--- a/service/drivers_service.py
+++ b/service/drivers_service.py
@@ -1,0 +1,149 @@
+"""D-Bus service for ubuntu-drivers-common."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+import UbuntuDrivers.detect
+
+import apt_pkg
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+import os
+
+sys_path = os.environ.get("UBUNTU_DRIVERS_SYS_DIR")
+
+
+def build_drivers_payload() -> List[Dict[str, Any]]:
+    """Return the drivers payload for the D-Bus API."""
+
+    apt_pkg.init_config()
+    apt_pkg.init_system()
+    try:
+        cache = apt_pkg.Cache(None)
+    except Exception as ex:
+        print(ex)
+        return []
+
+    devices = UbuntuDrivers.detect.system_device_drivers(
+        apt_cache=cache, sys_path=sys_path, freeonly=False
+    )
+
+    if devices is None:
+        return []
+
+    payload: List[Dict[str, Any]] = []
+
+    for device_name in sorted(devices):
+        info = devices[device_name]
+        drivers_info = info.get("drivers", {})
+        drivers_list: List[Dict[str, Any]] = []
+
+        for pkg_name, pkg_info in sorted(
+            drivers_info.items(),
+            key=lambda item: (not item[1].get("recommended", False), item[0]),
+        ):
+            drivers_list.append(
+                {
+                    "name": pkg_name,
+                    "source": "distro"
+                    if pkg_info.get("from_distro", False)
+                    else "third-party",
+                    "free": bool(pkg_info.get("free", False)),
+                    "builtin": bool(pkg_info.get("builtin", False)),
+                }
+            )
+
+        payload.append(
+            {
+                "sys_path": device_name,
+                "modalias": info.get("modalias", ""),
+                "vendor": info.get("vendor", ""),
+                "model": info.get("model", ""),
+                "drivers": drivers_list,
+            }
+        )
+
+    return payload
+
+
+def _to_dbus_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return dbus.Dictionary(
+            {str(k): _to_dbus_value(v) for k, v in value.items()},
+            signature="sv",
+        )
+    if isinstance(value, list):
+        if not value:
+            return dbus.Array([], signature="a{sv}")
+        if all(isinstance(item, dict) for item in value):
+            return dbus.Array(
+                [_to_dbus_value(item) for item in value], signature="a{sv}"
+            )
+        return dbus.Array([_to_dbus_value(item) for item in value], signature="v")
+    if isinstance(value, bool):
+        return dbus.Boolean(value)
+    if isinstance(value, str):
+        return dbus.String(value)
+    return value
+
+
+def _to_dbus_payload(payload: List[Dict[str, Any]]) -> dbus.Array:
+    return dbus.Array([_to_dbus_value(item) for item in payload], signature="a{sv}")
+
+
+class DriversService(dbus.service.Object):
+    """D-Bus service exposing driver detection results."""
+
+    BUS_NAME = "org.ubuntu.Drivers"
+    OBJ_PATH = "/org/ubuntu/Drivers"
+
+    def __init__(
+        self,
+        bus: "dbus.Bus",
+        idle_timeout_seconds: int = 300,
+        mainloop: Optional["GLib.MainLoop"] = None,
+    ) -> None:
+        self._idle_timeout_seconds = idle_timeout_seconds
+        self._last_activity = time.time()
+        self._mainloop = mainloop
+
+        super().__init__(bus, self.OBJ_PATH)
+
+        if self._mainloop is not None:
+            GLib.timeout_add_seconds(60, self._check_idle)
+
+    def _touch(self) -> None:
+        self._last_activity = time.time()
+
+    def _check_idle(self) -> bool:
+        if self._mainloop is None:
+            return True
+
+        if time.time() - self._last_activity >= self._idle_timeout_seconds:
+            self._mainloop.quit()
+            return False
+
+        return True
+
+    @dbus.service.method(BUS_NAME, in_signature="", out_signature="aa{sv}")
+    def drivers(self) -> List[Dict[str, Any]]:
+        """Return the list of devices and their available drivers."""
+
+        self._touch()
+        return _to_dbus_payload(build_drivers_payload())
+
+
+def main() -> None:
+    """Run the D-Bus service main loop."""
+
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    bus = dbus.SessionBus()
+    dbus.service.BusName(DriversService.BUS_NAME, bus)
+
+    loop = GLib.MainLoop()
+    DriversService(bus, mainloop=loop)
+    loop.run()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url="http://www.albertomilone.com",
     license="gpl",
     description="Detect and install additional Ubuntu driver packages",
-    packages=["Quirks", "UbuntuDrivers"],
+    packages=["Quirks", "UbuntuDrivers", "UbuntuDrivers/service"],
     data_files=[
         (
             "/usr/share/ubuntu-drivers-common/",
@@ -41,6 +41,8 @@ setup(
         ("/usr/share/doc/ubuntu-drivers-common", ["README"]),
         ("/usr/lib/nvidia/", glob.glob("nvidia-installer-hooks/*")),
         ("/usr/lib/ubiquity/target-config", glob.glob("ubiquity/target-config/*")),
+        ("/usr/lib/systemd/user/", ["systemd/ubuntu-drivers.service"]),
+        ("/usr/libexec/", ["ubuntu-drivers-dbus-service"]),
     ]
     + extra_data,
     scripts=["quirks-handler", "ubuntu-drivers"],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 import subprocess, glob, os.path
 import os
@@ -29,7 +29,7 @@ setup(
     url="http://www.albertomilone.com",
     license="gpl",
     description="Detect and install additional Ubuntu driver packages",
-    packages=["Quirks", "UbuntuDrivers", "UbuntuDrivers/service"],
+    packages=find_packages(),
     data_files=[
         (
             "/usr/share/ubuntu-drivers-common/",
@@ -43,6 +43,7 @@ setup(
         ("/usr/lib/ubiquity/target-config", glob.glob("ubiquity/target-config/*")),
         ("/usr/lib/systemd/user/", ["systemd/ubuntu-drivers.service"]),
         ("/usr/libexec/", ["ubuntu-drivers-dbus-service"]),
+        ("/usr/share/dbus-1/services/", ["systemd/org.ubuntu.Drivers.service"]),
     ]
     + extra_data,
     scripts=["quirks-handler", "ubuntu-drivers"],

--- a/systemd/org.ubuntu.Drivers.service
+++ b/systemd/org.ubuntu.Drivers.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.ubuntu.Drivers
+Exec=/bin/false
+SystemdService=ubuntu-drivers.service

--- a/systemd/ubuntu-drivers.service
+++ b/systemd/ubuntu-drivers.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Ubuntu Drivers D-Bus Service
+
+[Service]
+Type=dbus
+BusName=org.ubuntu.Drivers
+ExecStart=/usr/libexec/ubuntu-drivers-dbus-service
+StandardOutput=journal
+StandardError=journal
+Environment=PYTHONUNBUFFERED=1

--- a/tests/run
+++ b/tests/run
@@ -19,16 +19,16 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import unittest, os.path, sys, logging, os, atexit
+import unittest, os.path, sys, logging, os, atexit, shutil
 import getopt
 
 def usage():
     instructionsList = ['The only accepted (optional) parameters are:'
     '\n  -o, --output=<dirname>', '\tthe directory where the results \n\
 \t\t\t\tof the tests are saved.'
-    
+
     '\n  -i, --input=<filename>', '\tthe xorg.conf used for the tests.'
-    
+
     '\n  -h, --help', '\t\t\thelp page.'
 
     '\n  [Test ...]', '\t\t\tList of tests, the entire testsuite will be executed otherwise.'
@@ -40,7 +40,7 @@ def main():
     inputFile = os.path.join(cwd, 'xorg.conf')
     outputDir = cwd
     err = 'Error: parameters not recognised'
-    
+
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'h:o:i:', ['help', 'output=', 'input='])
     except getopt.GetoptError as err:
@@ -60,16 +60,16 @@ def main():
             sys.exit()
         else:
             assert False, 'unhandled option'
-    
-    
+
+
     settingsFile = open('settings.py', 'w')
     atexit.register(os.unlink, 'settings.py')
     if inputFile == os.path.join(cwd, 'xorg.conf') and outputDir == cwd:
         settingsFile.write('import os\ncwd = os.getcwd()\ninputFile = os.path.join(cwd, "xorg.conf")\noutputDir = cwd\ninputDir = cwd.replace("tests", "quirks")')
-    else:    
+    else:
         settingsFile.write('inputFile = "%s"\noutputDir = "%s"' % (inputFile, outputDir))
     settingsFile.close()
-        
+
     # run all tests in our directory
     if args:
         suite = unittest.TestLoader().loadTestsFromNames(args)
@@ -84,6 +84,10 @@ def main():
 if __name__ == '__main__':
     # run ourselves through umockdev-wrapper
     if 'umockdev' not in os.environ.get('LD_PRELOAD', ''):
-        os.execvp('umockdev-wrapper', ['umockdev-wrapper'] + sys.argv)
+        wrapper = shutil.which('umockdev-wrapper')
+        if wrapper:
+            os.execvp(wrapper, ['umockdev-wrapper'] + sys.argv)
+        else:
+            print('Warning: umockdev-wrapper not found; running tests without it.')
 
     sys.exit(main())

--- a/tests/test_drivers_service.py
+++ b/tests/test_drivers_service.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python3
+
+import os
+import shutil
+import signal
+import subprocess
+import threading
+import unittest
+from unittest.mock import patch
+
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+from service import drivers_service
+
+
+def _normalize_dbus_value(value):
+    if isinstance(value, dbus.Array):
+        return [_normalize_dbus_value(item) for item in value]
+    if isinstance(value, dbus.Dictionary):
+        return {str(k): _normalize_dbus_value(v) for k, v in value.items()}
+    if isinstance(value, (dbus.String, dbus.ObjectPath)):
+        return str(value)
+    if isinstance(value, dbus.Boolean):
+        return bool(value)
+    if isinstance(value, (dbus.Int32, dbus.Int64, dbus.UInt32, dbus.UInt64)):
+        return int(value)
+    return value
+
+
+class DriversServiceDbusTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not shutil.which("dbus-daemon"):
+            raise unittest.SkipTest("dbus-daemon is required for this test")
+
+        output = subprocess.check_output(
+            [
+                "dbus-daemon",
+                "--session",
+                "--print-address=1",
+                "--print-pid=1",
+                "--fork",
+                "--nopidfile",
+            ]
+        )
+        lines = output.decode().strip().splitlines()
+        if len(lines) < 2:
+            raise RuntimeError("Failed to start dbus-daemon for tests")
+
+        cls._dbus_address = lines[0].strip()
+        cls._dbus_pid = int(lines[1].strip())
+        cls._old_dbus_address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
+        os.environ["DBUS_SESSION_BUS_ADDRESS"] = cls._dbus_address
+
+        cls._service_ready = threading.Event()
+
+        def _run_service() -> None:
+            dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+            cls._bus = dbus.bus.BusConnection(cls._dbus_address)
+            cls._loop = GLib.MainLoop()
+            cls._bus_name = dbus.service.BusName(
+                drivers_service.DriversService.BUS_NAME, cls._bus
+            )
+            cls._service = drivers_service.DriversService(
+                cls._bus, mainloop=cls._loop, idle_timeout_seconds=300
+            )
+            cls._service_ready.set()
+            cls._loop.run()
+
+        cls._loop_thread = threading.Thread(target=_run_service, daemon=True)
+        cls._loop_thread.start()
+        if not cls._service_ready.wait(timeout=5):
+            raise RuntimeError("D-Bus service thread failed to start")
+
+        cls._client_bus = dbus.bus.BusConnection(cls._dbus_address)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_loop"):
+            cls._loop.quit()
+        if hasattr(cls, "_loop_thread"):
+            cls._loop_thread.join(timeout=2)
+
+        if hasattr(cls, "_bus"):
+            try:
+                cls._bus.release_name(drivers_service.DriversService.BUS_NAME)
+            except dbus.DBusException:
+                pass
+
+        if hasattr(cls, "_bus_name"):
+            del cls._bus_name
+
+        if hasattr(cls, "_bus"):
+            cls._bus.close()
+
+        if hasattr(cls, "_client_bus"):
+            cls._client_bus.close()
+
+        if hasattr(cls, "_dbus_pid"):
+            try:
+                os.kill(cls._dbus_pid, signal.SIGTERM)
+            except OSError:
+                pass
+
+        if hasattr(cls, "_old_dbus_address"):
+            if cls._old_dbus_address is None:
+                os.environ.pop("DBUS_SESSION_BUS_ADDRESS", None)
+            else:
+                os.environ["DBUS_SESSION_BUS_ADDRESS"] = cls._old_dbus_address
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_dbus_drivers_method(self, mock_detect):
+        device_path = "/sys/devices/pci0000:00/0000:00:01.0/0000:01:00.0"
+        mock_detect.return_value = {
+            device_path: {
+                "modalias": "pci:v000010DEd00001C8Dsv00001558sd0000852Bbc03sc00i00",
+                "vendor": "NVIDIA Corporation",
+                "model": "GP107M [GeForce GTX 1050 Mobile]",
+                "drivers": {
+                    "xserver-xorg-video-nouveau": {
+                        "free": True,
+                        "from_distro": True,
+                        "builtin": True,
+                        "recommended": False,
+                    },
+                    "nvidia-driver-570": {
+                        "free": False,
+                        "from_distro": False,
+                        "builtin": False,
+                        "recommended": True,
+                    },
+                },
+            }
+        }
+
+        proxy = self._client_bus.get_object(
+            drivers_service.DriversService.BUS_NAME,
+            drivers_service.DriversService.OBJ_PATH,
+        )
+        iface = dbus.Interface(proxy, drivers_service.DriversService.BUS_NAME)
+
+        # Call the dbus method
+        result = iface.drivers(timeout=5)
+
+        result = _normalize_dbus_value(result)
+
+        self.assertEqual(result[0]["sys_path"], device_path)
+        self.assertEqual(
+            [driver["name"] for driver in result[0]["drivers"]],
+            ["nvidia-driver-570", "xserver-xorg-video-nouveau"],
+        )
+        self.assertEqual(result[0]["drivers"][0]["source"], "third-party")
+        self.assertEqual(result[0]["drivers"][1]["source"], "distro")
+        self.assertTrue(result[0]["drivers"][1]["builtin"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_drivers_service.py
+++ b/tests/test_drivers_service.py
@@ -5,15 +5,17 @@ import shutil
 import signal
 import subprocess
 import threading
+import time
 import unittest
-from unittest.mock import patch
+import xml.etree.ElementTree as ET
+from unittest.mock import patch, MagicMock
 
 import dbus
 import dbus.service
 import dbus.mainloop.glib
 from gi.repository import GLib
 
-from service import drivers_service
+from UbuntuDrivers.service import drivers_service
 
 
 def _normalize_dbus_value(value):
@@ -157,6 +159,358 @@ class DriversServiceDbusTests(unittest.TestCase):
         self.assertEqual(result[0]["drivers"][0]["source"], "third-party")
         self.assertEqual(result[0]["drivers"][1]["source"], "distro")
         self.assertTrue(result[0]["drivers"][1]["builtin"])
+
+    def test_dbus_drivers_signature(self):
+        proxy = self._client_bus.get_object(
+            drivers_service.DriversService.BUS_NAME,
+            drivers_service.DriversService.OBJ_PATH,
+        )
+        introspect_iface = dbus.Interface(proxy, "org.freedesktop.DBus.Introspectable")
+        xml = introspect_iface.Introspect()
+        root = ET.fromstring(xml)
+
+        method = root.find(
+            ".//interface[@name='org.ubuntu.Drivers']/method[@name='drivers']"
+        )
+        self.assertIsNotNone(method, "drivers method missing from introspection")
+        out_args = method.findall("./arg[@direction='out']")
+        self.assertTrue(out_args, "drivers method has no out args")
+        # D-Bus introspection uses "type" for argument signature.
+        self.assertEqual(out_args[0].get("type"), "aa{sv}")
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_dbus_drivers_empty_devices(self, mock_detect):
+        """Test drivers method with no devices."""
+        mock_detect.return_value = {}
+
+        proxy = self._client_bus.get_object(
+            drivers_service.DriversService.BUS_NAME,
+            drivers_service.DriversService.OBJ_PATH,
+        )
+        iface = dbus.Interface(proxy, drivers_service.DriversService.BUS_NAME)
+
+        result = iface.drivers(timeout=5)
+        result = _normalize_dbus_value(result)
+
+        self.assertEqual(result, [])
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_dbus_drivers_no_drivers_for_device(self, mock_detect):
+        """Test device with no available drivers."""
+        device_path = "/sys/devices/pci0000:00/0000:00:02.0"
+        mock_detect.return_value = {
+            device_path: {
+                "modalias": "pci:v00008086d000012B9sv00008086sd0000FFFABC03sc00i00",
+                "vendor": "Intel Corporation",
+                "model": "Test Device",
+                "drivers": {},
+            }
+        }
+
+        proxy = self._client_bus.get_object(
+            drivers_service.DriversService.BUS_NAME,
+            drivers_service.DriversService.OBJ_PATH,
+        )
+        iface = dbus.Interface(proxy, drivers_service.DriversService.BUS_NAME)
+
+        result = iface.drivers(timeout=5)
+        result = _normalize_dbus_value(result)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["sys_path"], device_path)
+        self.assertEqual(result[0]["drivers"], [])
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_dbus_drivers_multiple_devices(self, mock_detect):
+        """Test with multiple devices."""
+        mock_detect.return_value = {
+            "/sys/devices/pci0000:00/0000:00:01.0": {
+                "modalias": "pci:v000010DEd00001C8Dsv00001558sd0000852Bbc03sc00i00",
+                "vendor": "NVIDIA",
+                "model": "GPU 1",
+                "drivers": {
+                    "nvidia-driver-570": {
+                        "free": False,
+                        "from_distro": False,
+                        "builtin": False,
+                        "recommended": True,
+                    }
+                },
+            },
+            "/sys/devices/pci0000:00/0000:00:02.0": {
+                "modalias": "pci:v00008086d000012B9sv00008086sd0000FFFABC03sc00i00",
+                "vendor": "Intel",
+                "model": "iGPU",
+                "drivers": {
+                    "i915": {
+                        "free": True,
+                        "from_distro": True,
+                        "builtin": True,
+                        "recommended": True,
+                    }
+                },
+            },
+        }
+
+        proxy = self._client_bus.get_object(
+            drivers_service.DriversService.BUS_NAME,
+            drivers_service.DriversService.OBJ_PATH,
+        )
+        iface = dbus.Interface(proxy, drivers_service.DriversService.BUS_NAME)
+
+        result = iface.drivers(timeout=5)
+        result = _normalize_dbus_value(result)
+
+        self.assertEqual(len(result), 2)
+        # Devices should be sorted by sys_path
+        self.assertEqual(result[0]["sys_path"], "/sys/devices/pci0000:00/0000:00:01.0")
+        self.assertEqual(result[1]["sys_path"], "/sys/devices/pci0000:00/0000:00:02.0")
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_dbus_drivers_sorting(self, mock_detect):
+        """Test that drivers are sorted with recommended first."""
+        device_path = "/sys/devices/pci0000:00/0000:00:01.0"
+        mock_detect.return_value = {
+            device_path: {
+                "modalias": "pci:v000010DEd00001C8D",
+                "vendor": "NVIDIA",
+                "model": "GPU",
+                "drivers": {
+                    "xserver-xorg-video-nouveau": {
+                        "free": True,
+                        "from_distro": True,
+                        "builtin": True,
+                        "recommended": False,
+                    },
+                    "nouveau-firmware": {
+                        "free": True,
+                        "from_distro": True,
+                        "builtin": False,
+                        "recommended": False,
+                    },
+                    "nvidia-driver-570": {
+                        "free": False,
+                        "from_distro": False,
+                        "builtin": False,
+                        "recommended": True,
+                    },
+                },
+            }
+        }
+
+        proxy = self._client_bus.get_object(
+            drivers_service.DriversService.BUS_NAME,
+            drivers_service.DriversService.OBJ_PATH,
+        )
+        iface = dbus.Interface(proxy, drivers_service.DriversService.BUS_NAME)
+
+        result = iface.drivers(timeout=5)
+        result = _normalize_dbus_value(result)
+
+        driver_names = [driver["name"] for driver in result[0]["drivers"]]
+        # Recommended driver should be first
+        self.assertEqual(driver_names[0], "nvidia-driver-570")
+        # Non-recommended drivers should be sorted alphabetically
+        self.assertIn("nouveau-firmware", driver_names[1:])
+        self.assertIn("xserver-xorg-video-nouveau", driver_names[1:])
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_dbus_drivers_driver_attributes(self, mock_detect):
+        """Test that driver attributes are correctly mapped."""
+        device_path = "/sys/devices/pci0000:00/0000:00:01.0"
+        mock_detect.return_value = {
+            device_path: {
+                "modalias": "pci:v000010DEd00001C8D",
+                "vendor": "NVIDIA",
+                "model": "GPU",
+                "drivers": {
+                    "distro-free": {
+                        "free": True,
+                        "from_distro": True,
+                        "builtin": True,
+                        "recommended": False,
+                    },
+                    "distro-nonfree": {
+                        "free": False,
+                        "from_distro": True,
+                        "builtin": False,
+                        "recommended": False,
+                    },
+                    "third-party-free": {
+                        "free": True,
+                        "from_distro": False,
+                        "builtin": False,
+                        "recommended": False,
+                    },
+                },
+            }
+        }
+
+        proxy = self._client_bus.get_object(
+            drivers_service.DriversService.BUS_NAME,
+            drivers_service.DriversService.OBJ_PATH,
+        )
+        iface = dbus.Interface(proxy, drivers_service.DriversService.BUS_NAME)
+
+        result = iface.drivers(timeout=5)
+        result = _normalize_dbus_value(result)
+
+        drivers_by_name = {d["name"]: d for d in result[0]["drivers"]}
+
+        # Test distro free driver
+        self.assertEqual(drivers_by_name["distro-free"]["source"], "distro")
+        self.assertTrue(drivers_by_name["distro-free"]["free"])
+        self.assertTrue(drivers_by_name["distro-free"]["builtin"])
+
+        # Test distro non-free driver
+        self.assertEqual(drivers_by_name["distro-nonfree"]["source"], "distro")
+        self.assertFalse(drivers_by_name["distro-nonfree"]["free"])
+        self.assertFalse(drivers_by_name["distro-nonfree"]["builtin"])
+
+        # Test third-party driver
+        self.assertEqual(drivers_by_name["third-party-free"]["source"], "third-party")
+        self.assertTrue(drivers_by_name["third-party-free"]["free"])
+        self.assertFalse(drivers_by_name["third-party-free"]["builtin"])
+
+
+class BuildDriversPayloadTests(unittest.TestCase):
+    """Tests for the build_drivers_payload helper function."""
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_build_drivers_payload_empty(self, mock_detect):
+        """Test with no devices."""
+        mock_detect.return_value = {}
+        result = drivers_service.build_drivers_payload()
+        self.assertEqual(result, [])
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_build_drivers_payload_single_device(self, mock_detect):
+        """Test with a single device."""
+        mock_detect.return_value = {
+            "/sys/devices/pci0000:00/0000:00:01.0": {
+                "modalias": "pci:v000010DEd00001C8D",
+                "vendor": "NVIDIA",
+                "model": "GPU",
+                "drivers": {
+                    "nvidia-driver-570": {
+                        "free": False,
+                        "from_distro": False,
+                        "builtin": False,
+                        "recommended": True,
+                    }
+                },
+            }
+        }
+
+        result = drivers_service.build_drivers_payload()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["sys_path"], "/sys/devices/pci0000:00/0000:00:01.0")
+        self.assertEqual(result[0]["vendor"], "NVIDIA")
+        self.assertEqual(result[0]["model"], "GPU")
+        self.assertEqual(len(result[0]["drivers"]), 1)
+        self.assertEqual(result[0]["drivers"][0]["name"], "nvidia-driver-570")
+
+    @patch(
+        "UbuntuDrivers.service.drivers_service.UbuntuDrivers.detect.system_device_drivers"
+    )
+    def test_build_drivers_payload_missing_optional_fields(self, mock_detect):
+        """Test handling of devices with missing optional fields."""
+        mock_detect.return_value = {
+            "/sys/devices/pci0000:00/0000:00:01.0": {
+                # modalias, vendor, model are optional
+                "drivers": {}
+            }
+        }
+
+        result = drivers_service.build_drivers_payload()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["sys_path"], "/sys/devices/pci0000:00/0000:00:01.0")
+        self.assertEqual(result[0]["modalias"], "")
+        self.assertEqual(result[0]["vendor"], "")
+        self.assertEqual(result[0]["model"], "")
+
+
+class DriversServiceUnitTests(unittest.TestCase):
+    """Unit tests for DriversService class methods."""
+
+    def test_drivers_service_initialization(self):
+        """Test DriversService initialization without mainloop."""
+        bus = MagicMock(spec=dbus.Bus)
+        service = drivers_service.DriversService(bus)
+
+        self.assertEqual(service.BUS_NAME, "org.ubuntu.Drivers")
+        self.assertEqual(service.OBJ_PATH, "/org/ubuntu/Drivers")
+        self.assertEqual(service._idle_timeout_seconds, 300)
+        self.assertIsNone(service._mainloop)
+
+    def test_drivers_service_initialization_with_timeout(self):
+        """Test DriversService initialization with custom timeout."""
+        bus = MagicMock(spec=dbus.Bus)
+        service = drivers_service.DriversService(bus, idle_timeout_seconds=60)
+
+        self.assertEqual(service._idle_timeout_seconds, 60)
+
+    def test_drivers_service_touch(self):
+        """Test that _touch updates last activity time."""
+        bus = MagicMock(spec=dbus.Bus)
+        service = drivers_service.DriversService(bus)
+
+        initial_time = service._last_activity
+        time.sleep(0.01)  # Small delay to ensure time difference
+        service._touch()
+
+        self.assertGreater(service._last_activity, initial_time)
+
+    def test_drivers_service_check_idle_no_mainloop(self):
+        """Test _check_idle returns True when no mainloop."""
+        bus = MagicMock(spec=dbus.Bus)
+        service = drivers_service.DriversService(bus)
+
+        result = service._check_idle()
+        self.assertTrue(result)
+
+    def test_drivers_service_check_idle_not_expired(self):
+        """Test _check_idle returns True when timeout not reached."""
+        bus = MagicMock(spec=dbus.Bus)
+        mainloop = MagicMock(spec=GLib.MainLoop)
+        service = drivers_service.DriversService(
+            bus, idle_timeout_seconds=300, mainloop=mainloop
+        )
+
+        result = service._check_idle()
+        self.assertTrue(result)
+        mainloop.quit.assert_not_called()
+
+    def test_drivers_service_check_idle_expired(self):
+        """Test _check_idle quits mainloop when timeout expired."""
+        bus = MagicMock(spec=dbus.Bus)
+        mainloop = MagicMock(spec=GLib.MainLoop)
+        service = drivers_service.DriversService(
+            bus,
+            idle_timeout_seconds=0,
+            mainloop=mainloop,  # Immediate timeout
+        )
+
+        # Immediately call _check_idle should detect timeout
+        result = service._check_idle()
+        self.assertFalse(result)
+        mainloop.quit.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -60,6 +60,7 @@ class TestStatic(unittest.TestCase):
             "debian",
             # Project dirs ignored for the moment
             "Quirks",
+            ".pybuild",
         ]
         # List of files to ignore with ../ stripped from the beginning of the path
         ignore_files = [
@@ -104,7 +105,11 @@ class TestStatic(unittest.TestCase):
         output = subp.communicate()[0].splitlines()
         for line in output:
             print(line)
-        self.assertEqual(0, len(output))
+        self.assertEqual(
+            0,
+            len(output),
+            "pycodestyle errors:\n%s" % "\n".join(output) if output else "",
+        )
 
     @unittest.skipUnless(
         find_on_path(pyflakes_cmd), "%s not found on this system" % pyflakes_cmd
@@ -129,6 +134,7 @@ class TestStatic(unittest.TestCase):
             universal_newlines=True,
         )
         output = subp.communicate()[0].splitlines()
+        failing_lines = []
         for line in output:
             if line.startswith("#"):
                 continue
@@ -137,6 +143,10 @@ class TestStatic(unittest.TestCase):
             canon_line = re.sub(r"line [0-9]+", "line *", canon_line)
             if canon_line not in exclusions:
                 print(line)
+                failing_lines.append(line)
                 error = True
 
-        self.assertFalse(error)
+        self.assertFalse(
+            error,
+            "pyflakes errors:\n%s" % "\n".join(failing_lines) if failing_lines else "",
+        )

--- a/ubuntu-drivers-dbus-service
+++ b/ubuntu-drivers-dbus-service
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+"""Entry point for the ubuntu-drivers D-Bus service."""
+
+from UbuntuDrivers import service
+
+if __name__ == "__main__":
+    from UbuntuDrivers.service.drivers_service import main
+
+    main()


### PR DESCRIPTION
A D-Bus service is added to query ubuntu-drivers from anywhere including from a confioned package.
The service exposes a single method called `drivers`. This method returns a dict of devices and for each device the list of supported drivers with details about the driver.
The service is d-bus activated and shuts down after 5 minutes.
