### PR TITLE
Fix some lintian warnings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -76,7 +76,7 @@ ubuntu-drivers-common (1:0.10.2ubuntu1) questing; urgency=medium
 
   * Clarify gpgpu flag help text (LP: #2115537)
 
- -- Mitchell Augustin <mitchell.augustin@canonical.com> Tue, 01 Jul 2025 16:46:31 -0500
+ -- Mitchell Augustin <mitchell.augustin@canonical.com>  Tue, 01 Jul 2025 16:46:31 -0500
 
 ubuntu-drivers-common (1:0.10.2) plucky; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -148,7 +148,7 @@ ubuntu-drivers-common (1:0.9.7.7) oracular; urgency=medium
     - Change Makefile to respect CC and CFLAGS environment variables
   * share/hybrid/71-u-d-c-gpu-detection.rules
     - Remove SimpleDRM device when nvidia-drm loads (LP: #2060268)
-  * share/hybrid/gpu-manager.c  
+  * share/hybrid/gpu-manager.c
     - Wait for nvidia-drm to settle before opening /dev/dri/card* (LP: #2060268)
 
  -- Kuba Pawlak <kuba.pawlak@canonical.com>  Wed, 24 Jul 2024 11:00:58 +0200
@@ -1900,7 +1900,7 @@ ubuntu-drivers-common (1:0.2.69) quantal; urgency=low
     (LP: #1045629)
   * setup.py: Only install the upstart job on platforms where we build
     hybrid-detect. (LP: #1045193)
-  * debian/rules: On architectures which do not ship hybrid-detect, generate a 
+  * debian/rules: On architectures which do not ship hybrid-detect, generate a
     .maintscript helper to clean up the /etc/init/hybrid-gfx.conf upstart job
     conffile on upgrade.
   * tests/ubuntu_drivers.py: Add test for a video driver which supports
@@ -2412,7 +2412,7 @@ nvidia-common (0.2.27) natty; urgency=low
 
   * nvidia-detector:
     - Initialise NvidiaDetection() with verbose=False. This should avoid
-      problems when dealing with debconf (LP: #698327). 
+      problems when dealing with debconf (LP: #698327).
 
  -- Alberto Milone <alberto.milone@canonical.com>  Tue, 18 Jan 2011 18:15:44 +0100
 
@@ -2524,7 +2524,7 @@ nvidia-common (0.2.18) lucid; urgency=low
       adapt to the fact that the alternative lives in mesa now.
     - Do not pass arguments to the list_alternatives method.
     - Use subprocess.check_call instead of .call so as to get the exit
-      status in addition to the return code. 
+      status in addition to the return code.
 
  -- Alberto Milone <alberto.milone@canonical.com>  Tue, 19 Jan 2010 17:18:45 +0100
 
@@ -2653,7 +2653,7 @@ nvidia-common (0.2.7) jaunty; urgency=low
 nvidia-common (0.2.6) jaunty; urgency=low
 
   * debian/control:
-    - Drop dependency on nvidia-177-modaliases since it's not 
+    - Drop dependency on nvidia-177-modaliases since it's not
       compatible with Jaunty's X ABI.
     - Add Vcs-Bzr
 

--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,5 @@
 Source: ubuntu-drivers-common
 Section: admin
-Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13),
  dh-python,

--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Build-Depends: debhelper-compat (= 13),
  black,
  mokutil [!s390x],
 Standards-Version: 3.9.8
-Vcs-Git: git://github.com/canonical/ubuntu-drivers-common.git
+Vcs-Git: https://github.com/canonical/ubuntu-drivers-common.git
 Vcs-Browser: https://github.com/canonical/ubuntu-drivers-common
 
 Package: ubuntu-drivers-common

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Files: *
 Copyright: Copyright (c) 2008 Alberto Milone
 License: GPL-2+
 
-Files: UbuntuDrivers/* tests/ubuntu_drivers.py ubuntu-drivers
+Files: UbuntuDrivers/* tests/test_ubuntu_drivers.py ubuntu-drivers
 Copyright: Copyright (c) 2012 Canonical Ltd.
 License: GPL-2+
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
 Copyright: Copyright (c) 2008 Alberto Milone

--- a/debian/rules
+++ b/debian/rules
@@ -20,16 +20,10 @@ ifeq (, $(findstring nocheck, $(DEB_BUILD_OPTIONS)))
 endif
 
 override_dh_install:
-	dh_install -Xlib/systemd -Xsbin -Xlib/udev
-
-	# on architectures where we build gpu-manager, install the systemd unit,
-	# the udev rule, and the script for gpu detection
-	if [ -d debian/tmp/lib/systemd ]; then \
-		dh_install -p ubuntu-drivers-common lib/systemd; \
-		dh_systemd_enable -p ubuntu-drivers-common; \
-		dh_install -p ubuntu-drivers-common lib/udev/rules.d; \
-		dh_install -p ubuntu-drivers-common sbin; \
-	fi
+	# on architectures where we build gpu-manager, this also picks up the
+	# systemd unit, the udev rule and the script for gpu detection; they all
+	# live under /usr now, so debian/ubuntu-drivers-common.install covers them
+	dh_install
 
 	# build dh_modaliases manpage
 	mkdir -p debian/dh-modaliases/usr/share/man/man1

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-DEB_VERSION=$(shell dpkg-parsechangelog | grep ^Version | cut -f2 -d\ |cut -f1 -d-)
+include /usr/share/dpkg/pkg-info.mk
 DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 TEST_ARCHES=amd64 arm64
 PYBUILD_NAME=ubuntu-drivers-common
@@ -33,7 +33,7 @@ override_dh_install:
 
 	# build dh_modaliases manpage
 	mkdir -p debian/dh-modaliases/usr/share/man/man1
-	pod2man -c Debhelper -r "$(DEB_VERSION)" debhelper/dh_modaliases debian/dh-modaliases/usr/share/man/man1/dh_modaliases.1
+	pod2man -c Debhelper -r "$(DEB_VERSION_EPOCH_UPSTREAM)" debhelper/dh_modaliases debian/dh-modaliases/usr/share/man/man1/dh_modaliases.1
 
 override_dh_python3:
 	dh_python3 --shebang=/usr/bin/python3

--- a/debian/ubuntu-drivers-common.postinst
+++ b/debian/ubuntu-drivers-common.postinst
@@ -1,0 +1,10 @@
+#! /bin/sh
+set -e
+
+# The package ships a debconf config script and templates, so the postinst
+# has to load a debconf library too (see debconf-devel(7)).
+. /usr/share/debconf/confmodule
+
+#DEBHELPER#
+
+exit 0

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,12 @@ extra_data = []
 if "86" in os.uname()[4]:
     subprocess.check_call(["make", "-C", "share/hybrid", "all"])
     extra_data.append(("/usr/bin/", ["share/hybrid/gpu-manager"]))
-    extra_data.append(("/lib/systemd/system/", ["share/hybrid/gpu-manager.service"]))
-    extra_data.append(("/sbin/", ["share/hybrid/u-d-c-print-pci-ids"]))
     extra_data.append(
-        ("/lib/udev/rules.d/", ["share/hybrid/71-u-d-c-gpu-detection.rules"])
+        ("/usr/lib/systemd/system/", ["share/hybrid/gpu-manager.service"])
+    )
+    extra_data.append(("/usr/sbin/", ["share/hybrid/u-d-c-print-pci-ids"]))
+    extra_data.append(
+        ("/usr/lib/udev/rules.d/", ["share/hybrid/71-u-d-c-gpu-detection.rules"])
     )
 
 # Make the nvidia-installer hooks executable

--- a/share/hybrid/71-u-d-c-gpu-detection.rules
+++ b/share/hybrid/71-u-d-c-gpu-detection.rules
@@ -12,7 +12,7 @@ ACTION=="add", KERNEL=="card[0-9]*", SUBSYSTEM=="drm", DRIVERS=="nvidia", \
     ENV{U_D_C_MODESET}=="Y", ENV{U_D_C_FBDEV}!="Y", TEST=="/run/u-d-c-card0-is-simpledrm", RUN+="/bin/rm /dev/dri/card0"
 
 # Create a file with the card details for gpu-manager
-ACTION=="add", SUBSYSTEM=="drm", DEVPATH=="*/drm/card*", RUN+="/sbin/u-d-c-print-pci-ids"
+ACTION=="add", SUBSYSTEM=="drm", DEVPATH=="*/drm/card*", RUN+="/usr/sbin/u-d-c-print-pci-ids"
 
 # Create a file when a module is loaded
 ACTION=="add", SUBSYSTEMS=="pci", DRIVERS=="nvidia", RUN+="/bin/touch /run/u-d-c-nvidia-was-loaded"

--- a/share/hybrid/gpu-manager.c
+++ b/share/hybrid/gpu-manager.c
@@ -2816,7 +2816,7 @@ int main(int argc, char *argv[]) {
         pacc = pci_alloc();
 
         if (!pacc) {
-            fprintf(log_handle, "Error: failed to acces the PCI library\n");
+            fprintf(log_handle, "Error: failed to access the PCI library\n");
             goto end;
         }
         /* Initialize the PCI library */

--- a/share/hybrid/gpu-manager.service
+++ b/share/hybrid/gpu-manager.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Detect the available GPUs and deal with any system changes
+Documentation=https://github.com/canonical/ubuntu-drivers-common
 Before=display-manager.service
 Before=oem-config.service
 


### PR DESCRIPTION
This is just the ones claude could easily fix, there are more:

# Lintian findings without a clear fix

Everything else lintian reported has been fixed on the `fix/lintian-warnings`
branch (one commit per tag); 35 tag instances went down to the 11 below.

## How this was reproduced

```sh
# build deps
sudo apt-get install build-essential devscripts lintian equivs dpkg-dev fakeroot
sudo mk-build-deps --install --remove debian/control

# build (the parent directory must be writable, so build from a copy if the
# checkout lives on a read-only mount)
dpkg-buildpackage -us -uc -rfakeroot

# check
lintian -EvIL +pedantic --tag-display-limit 0 ../ubuntu-drivers-common_*_amd64.changes
```

Environment: Ubuntu 26.04 (resolute), lintian 2.129.0ubuntu2.1, debhelper 13.31,
dpkg-buildpackage on amd64.

## `groff-message` on `usr/share/man/man1/dh_modaliases.1.gz` (warning)

```
W: dh-modaliases: groff-message command exited with status 1: /usr/libexec/man-db/zsoelim | … | groff -mandoc …
```

**This is an artifact of the build container, not a defect in the manpage.** The
same tag appears when lintian is pointed at an unmodified archive package:

```
$ apt-get download hello && lintian hello_2.10-5build1_amd64.deb
W: hello: groff-message command exited with status 1: /usr/libexec/man-db/zsoelim | …
```

Running lintian's exact command by hand against the generated page
(`env -i PATH=… LC_ALL=C.UTF-8 MANROFFSEQ= MANWIDTH=119 man --warnings -E UTF-8
-l -Tutf8 -Z dh_modaliases.1.gz`) exits 0 with empty stderr, as does the raw
`zsoelim | manconv | preconv | groff` pipeline under every locale tried. Something
about man-db in this container fails only inside lintian's stripped environment.

**Action:** ignore here; re-check on a normal build machine (e.g. a sbuild chroot
or Launchpad builder) before concluding anything. No change to
`debhelper/dh_modaliases` is warranted based on this run.

## `no-manual-page` (warning, 4 instances)

`usr/bin/gpu-manager`, `usr/bin/quirks-handler`, `usr/bin/ubuntu-drivers`,
`usr/sbin/u-d-c-print-pci-ids`.

**No clear fix — this is content authoring, not a packaging change.** Writing four
accurate manpages requires knowledge of the intended user-facing contract for each
tool, which is a maintainer decision:

* `ubuntu-drivers` is the one that most deserves a page; it has a substantial
  `click`-based CLI (`list`, `list-oem`, `install`, `autoinstall`, `devices`,
  `debug`) and is the documented entry point for users and installers.
* `gpu-manager` and `u-d-c-print-pci-ids` are internal, invoked from the systemd
  unit and a udev rule respectively. A maintainer may reasonably decide these
  should not have manpages at all, in which case a `debian/*.lintian-overrides`
  entry is the right answer rather than a page.
* `quirks-handler` is likewise internal to the quirks mechanism.

Deferring rather than generating filler pages (e.g. from `--help` via `help2man`),
which would satisfy lintian without informing anyone.

## `systemd-service-file-refers-to-unusual-wantedby-target` (warning, 2 instances)

`gpu-manager.service` declares `WantedBy=display-manager.service` and
`WantedBy=oem-config.service`.

**Deliberate, and lintian cannot tell.** The unit's whole purpose is to settle GPU
driver configuration before a graphical session or the OEM setup tool starts; it
also carries the matching `Before=` directives. Changing the target would be a
behaviour regression.

**Recommended action (maintainer's call):** add a `debian/ubuntu-drivers-common.lintian-overrides`
with these two tags and a comment explaining the ordering requirement. Not applied
here because an override suppresses information rather than fixing anything, and
whether to carry one is a packaging-policy preference.

## `out-of-date-standards-version 3.9.8` (info)

Current Policy is 4.7.3; the declared version predates it by roughly nine years.

**Not bumped deliberately.** `Standards-Version` is an assertion by the maintainer
that the package has been reviewed against the Policy changes in that range — it is
not a field that can be correctly updated by mechanically raising the number. The
span 3.9.8 → 4.7.3 covers a large upgrading checklist.

That said, lintian reports no Policy violations against this package, and the
specific requirements that are easy to check are already satisfied:

* `debian/rules` supports `build-arch` / `build-indep` (provided by `dh`).
* `debian/copyright` uses the machine-readable 1.0 format.
* Priority/Section fields are valid; `Priority` is now omitted (default).
* No files installed into aliased locations.
* `Rules-Requires-Root` is not declared, so the default `binary-targets` applies,
  which is valid.

**Recommended action:** walk `/usr/share/doc/debian-policy/upgrading-checklist.txt.gz`
and bump the field in the same commit. Consider adding `Rules-Requires-Root: no`
at that point — the build does not appear to need root beyond `fakeroot`, but that
should be confirmed with an actual `--rules-requires-root=no` build.

## `unused-debconf-template ubuntu-drivers-common/obsolete-driver` (info)

Nothing in the tree references this template. Grepping the whole checkout, the only
hit is `debian/ubuntu-drivers-common.templates` itself.

**Not removed, because the template looks like it is driven from outside this
source package.** `debian/ubuntu-drivers-common.config` exists purely to make
debconf load the templates and says so:

```
# Do not remove this file. It's supposed to
# get debconf to load the template file
# when ubuntu-drivers-common is triggered by kernel
# hooks.
```

The template also uses a `${latest}` substitution variable, which implies some
other component sets it via `db_subst` and fires the note. Deleting it could
silently break that consumer.

**Recommended action:** identify the consumer (likely a kernel or NVIDIA package
hook). If it still exists, add a `lintian-overrides` entry citing it; if it does
not, drop the template, `debian/ubuntu-drivers-common.config`, the `po-debconf`
build-dependency and `debian/po/` together.

## `no-complete-debconf-translation` (info)

`debian/po/` contains `templates.pot` and no `.po` files, so no translation is
complete.

**No clear fix — needs translators, not code.** The `.pot` is also still carrying
the gettext boilerplate header (`SOME DESCRIPTIVE TITLE`, `FIRST AUTHOR
<EMAIL@ADDRESS>`), which is worth correcting whoever picks this up.

**Recommended action:** either call for translations with
`podebconf-report-po --call --withtranslators --deadline="+10 days"`, or — if the
`obsolete-driver` template turns out to be dead (see above) — retire the debconf
machinery entirely, which resolves this tag and `unused-debconf-template` at once.

## `executable-in-usr-lib` (experimental/pedantic)

`usr/lib/ubiquity/target-config/31ubuntu_driver_packages`.

**Cannot be fixed unilaterally.** FHS 3.0 wants executables in `/usr/libexec`, but
this path is not ours to choose: ubiquity scans `/usr/lib/ubiquity/target-config/`
for hooks and runs them. Moving the script there would mean it never runs.

**Recommended action:** none until ubiquity changes its search path. If the tag
becomes non-experimental, add an override referencing the ubiquity interface.

## Unrelated issue found while building

Not a lintian finding, but the build fails before it gets as far as producing
packages, so it is recorded here.

`debian/rules`' `override_dh_auto_test` runs `black --check`, which fails on
resolute:

```
would reformat /work/ubuntu-drivers-common/UbuntuDrivers/detect.py
1 file would be reformatted, 7 files would be left unchanged.
make[1]: *** [debian/rules:18: override_dh_auto_test] Error 1
```

This is black version drift, not a code defect — black 26.3.1 changed its
preferences for redundant parentheses around tuple unpacking targets and for
hugging a `%`-format operand:

```diff
-        (k, v) = line.split("=", 1)
+        k, v = line.split("=", 1)
-options nvidia-drm modeset=%d\n""" % (
-        value
-    )
+options nvidia-drm modeset=%d\n""" % (value)
```

The packages checked above were therefore built with `DEB_BUILD_OPTIONS=nocheck`.
The rest of the suite (`tests/run`, mypy) passes. Reformatting
`UbuntuDrivers/detect.py` with the current black is a separate change and was left
alone.
