### PR TITLE
Add DisplayLink USB detection plugin with vendor/model plugin metadata support

### DIFF
--- a/README
+++ b/README
@@ -89,6 +89,22 @@ which can do any kind of detection and then return the resulting set of
 packages that apply to the current system. Please note that this cannot rely on
 having root privileges.
 
+A plugin may alternatively return a dictionary in order to provide optional
+human readable vendor and model information about the detected device:
+
+   def detect(apt_cache):
+      # do detection logic here
+      return {
+          'packages': ['driver_package', ...],
+          'vendor': 'Vendor Name',   # optional
+          'model': 'Product Name',   # optional
+      }
+
+The "packages" key is mandatory and has the same meaning as the list return
+value above. The optional "vendor" and "model" strings are propagated into the
+information returned by system_driver_packages(), matching the metadata already
+available for modalias-based driver detection.
+
 
 Autopkgtest
 -----------

--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -58,6 +58,13 @@ class PackageInfo(TypedDict, total=False):
     metapackage: str
 
 
+class PluginMetadata(TypedDict, total=False):
+    """Optional metadata returned by a driver detection plugin."""
+
+    vendor: str
+    model: str
+
+
 system_architecture = ""
 lookup_cache = {}
 custom_supported_gpus_json = "/etc/custom_supported_gpus.json"
@@ -669,7 +676,7 @@ def _get_db_name(syspath: str, alias: str) -> Tuple[Optional[str], Optional[str]
     vendor = None
     model = None
     for line in out.splitlines():
-        (k, v) = line.split("=", 1)
+        k, v = line.split("=", 1)
         if "_VENDOR" in k:
             vendor = v
         if "_MODEL" in k:
@@ -779,7 +786,7 @@ def system_driver_packages(
                 "runtimepm": _is_runtimepm_supported(apt_cache, p, alias),
                 "open_preferred": _is_open_prefered(apt_cache, p),
             }
-            (vendor, model) = _get_db_name(syspath, alias)
+            vendor, model = _get_db_name(syspath, alias)
             if vendor is not None:
                 packages[p.name]["vendor"] = vendor
             if model is not None:
@@ -798,16 +805,39 @@ def system_driver_packages(
         for p in nvidia_packages:
             packages[p]["recommended"] = p == recommended
 
+    # Keep the existing package result returned by detect_plugin_packages(),
+    # while collecting optional metadata separately. This preserves
+    # compatibility with callers which expect a mapping of plugin names to
+    # package-name lists.
+    plugin_metadata: Dict[str, PluginMetadata] = {}
+    plugin_packages = detect_plugin_packages(
+        apt_cache,
+        plugin_metadata=plugin_metadata,
+    )
+
     # add available packages which need custom detection code
-    for plugin, pkgs in detect_plugin_packages(apt_cache).items():
+    for plugin, pkgs in plugin_packages.items():
+        metadata = plugin_metadata.get(plugin, {})
+
         for p in pkgs:
             try:
                 apt_p = apt_cache[p]
-                packages[p] = {
+
+                package_info: PackageInfo = {
                     "free": _is_package_free(apt_cache, apt_p),
                     "from_distro": _is_package_from_distro(apt_cache, apt_p),
                     "plugin": plugin,
                 }
+
+                vendor = metadata.get("vendor")
+                if vendor:
+                    package_info["vendor"] = vendor
+
+                model = metadata.get("model")
+                if model:
+                    package_info["model"] = model
+
+                packages[p] = package_info
             except KeyError:
                 logging.debug("Package %s plugin not available. Skipping." % p)
 
@@ -1015,7 +1045,7 @@ def system_gpgpu_driver_packages(
     modalias_map = apt_cache_modalias_map(apt_cache)
     for alias, syspath in modaliases.items():
         for p in packages_for_modalias(apt_cache, alias, modalias_map=modalias_map):
-            (vendor, model) = _get_db_name(syspath, alias)
+            vendor, model = _get_db_name(syspath, alias)
             vendor_id, model_id = _get_vendor_model_from_alias(alias)
             if (vendor_id is not None) and (vendor_id.lower() in vendors_whitelist):
                 packages[p.name] = {
@@ -1660,6 +1690,7 @@ def auto_install_filter(
 
 def detect_plugin_packages(
     apt_cache: Optional[apt_pkg.Cache] = None,
+    plugin_metadata: Optional[Dict[str, PluginMetadata]] = None,
 ) -> Dict[str, List[str]]:
     """Get driver packages from custom detection plugins.
 
@@ -1670,12 +1701,23 @@ def detect_plugin_packages(
     returned lists for packages which are available for installation, and
     return the joined results.
 
-    If you already have an existing apt_pkg.Cache() object, you can pass it as an
-    argument for efficiency.
+    Plugins normally return a list or set of package names. A plugin may
+    alternatively return a dictionary containing a mandatory "packages"
+    entry and optional "vendor" and "model" entries.
+
+    Optional metadata is copied into plugin_metadata, keyed by plugin
+    filename. The function's existing return type remains unchanged.
+
+    If you already have an existing apt_pkg.Cache() object, you
+    can pass it as an argument for efficiency.
 
     Return pluginname -> [package, ...] map.
     """
     packages: Dict[str, List[str]] = {}
+
+    if plugin_metadata is not None:
+        plugin_metadata.clear()
+
     plugindir = os.environ.get(
         "UBUNTU_DRIVERS_DETECT_DIR", "/usr/share/ubuntu-drivers-common/detect/"
     )
@@ -1708,23 +1750,68 @@ def detect_plugin_packages(
 
             if result is None:
                 continue
-            if type(result) not in (list, set):
+
+            result_packages = result
+            metadata: PluginMetadata = {}
+
+            if isinstance(result, dict):
+                result_packages = result.get("packages")
+
+                vendor = result.get("vendor")
+                if vendor is not None:
+                    if not isinstance(vendor, str):
+                        logging.error(
+                            "plugin %s returned a non-string vendor value",
+                            plugin,
+                        )
+                        continue
+                    metadata["vendor"] = vendor
+
+                model = result.get("model")
+                if model is not None:
+                    if not isinstance(model, str):
+                        logging.error(
+                            "plugin %s returned a non-string model value",
+                            plugin,
+                        )
+                        continue
+                    metadata["model"] = model
+
+            if not isinstance(result_packages, (list, set)):
                 logging.error(
-                    "plugin %s returned a bad type %s (must be list or set)",
+                    "plugin %s returned a bad package type %s" " (must be list or set)",
                     plugin,
-                    type(result),
+                    type(result_packages),
                 )
                 continue
 
-            for pkg in result:
+            valid_packages = []
+
+            for pkg in result_packages:
+                if not isinstance(pkg, str):
+                    logging.error(
+                        "plugin %s returned a non-string package name",
+                        plugin,
+                    )
+                    continue
+
                 try:
                     package = apt_cache[pkg]
                     if _check_video_abi_compat(apt_cache, package):
-                        packages.setdefault(fname, []).append(pkg)
+                        valid_packages.append(pkg)
                 except KeyError:
                     logging.debug(
-                        "Ignoring unavailable package %s from plugin %s", pkg, plugin
+                        "Ignoring unavailable package %s" " from plugin %s", pkg, plugin
                     )
+
+            if valid_packages:
+                # Sort and deduplicate the result to ensure deterministic
+                # output if a plugin encounters more than one matching
+                # device.
+                packages[fname] = sorted(set(valid_packages))
+
+                if plugin_metadata is not None and metadata:
+                    plugin_metadata[fname] = metadata
 
     return packages
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+ubuntu-drivers-common (1:0.10.10) resolute; urgency=medium
+
+  [ Marcin Grzegorz Kaspryk ]
+  * Add a DisplayLink USB device detection plugin, which recommends the
+    displaylink-driver package for DisplayLink (vendor 17e9) devices that are
+    not already handled by the in-kernel udl DRM driver.
+  * Support optional vendor/model metadata from driver detection plugins:
+    plugins may now return a dictionary with a mandatory "packages" key and
+    optional "vendor" and "model" entries, which are wired into
+    system_driver_packages().
+
+ -- Marcin Grzegorz Kaspryk <mkaspryk@synaptics.com>  Wed, 05 Aug 2026 12:00:00 +0200
+
 ubuntu-drivers-common (1:0.10.9) resolute; urgency=medium
 
   [ Mitchell Augustin ]

--- a/detect-plugins/displaylink.py
+++ b/detect-plugins/displaylink.py
@@ -1,0 +1,114 @@
+# Detect USB devices which may require the DisplayLink driver
+
+import os
+
+
+DISPLAYLINK_USB_VENDOR_ID = "17e9"
+DISPLAYLINK_DRIVER_PACKAGE = "displaylink-driver"
+USB_SYSFS_ROOT = "/sys/bus/usb/devices"
+
+# The in-kernel udl driver matches DisplayLink devices using interface
+# descriptors: bInterfaceClass=0xff, bInterfaceSubClass=0x00,
+# bInterfaceProtocol=0x00. See drivers/gpu/drm/udl/udl_drv.c in the
+# Linux kernel source.
+_UDL_INTERFACE_CLASS = "ff"
+_UDL_INTERFACE_SUBCLASS = "00"
+_UDL_INTERFACE_PROTOCOL = "00"
+
+
+def _read_sysfs_value(path):
+    """Read and return a stripped string from a sysfs attribute file."""
+    try:
+        with open(path, encoding="ascii") as attribute:
+            return attribute.read().strip()
+    except (OSError, UnicodeError):
+        return None
+
+
+def _matches_udl_interface(device_path):
+    """Check if any interface on the device matches the udl driver criteria."""
+    device_name = os.path.basename(device_path)
+    try:
+        entries = os.listdir(device_path)
+    except OSError:
+        return False
+
+    for entry in entries:
+        # Interface directories are named like "<device>:<config>.<iface>"
+        if not entry.startswith(device_name + ":"):
+            continue
+        iface_path = os.path.join(device_path, entry)
+        iface_class = _read_sysfs_value(
+            os.path.join(iface_path, "bInterfaceClass")
+        )
+        iface_subclass = _read_sysfs_value(
+            os.path.join(iface_path, "bInterfaceSubClass")
+        )
+        iface_protocol = _read_sysfs_value(
+            os.path.join(iface_path, "bInterfaceProtocol")
+        )
+        if (iface_class == _UDL_INTERFACE_CLASS
+                and iface_subclass == _UDL_INTERFACE_SUBCLASS
+                and iface_protocol == _UDL_INTERFACE_PROTOCOL):
+            return True
+
+    return False
+
+
+def _detect_displaylink_device(sysfs_root=USB_SYSFS_ROOT):
+    """Scan sysfs for a DisplayLink device needing the proprietary driver."""
+    try:
+        device_names = sorted(os.listdir(sysfs_root))
+    except OSError:
+        return None
+
+    for device_name in device_names:
+        device_path = os.path.join(sysfs_root, device_name)
+
+        vendor = _read_sysfs_value(os.path.join(device_path, "idVendor"))
+        if vendor is None or vendor.lower() != DISPLAYLINK_USB_VENDOR_ID:
+            continue
+
+        product_id = _read_sysfs_value(
+            os.path.join(device_path, "idProduct")
+        )
+        if product_id is None:
+            continue
+
+        # Devices already handled by the in-kernel udl driver should not
+        # cause the proprietary DisplayLink package to be recommended.
+        # The udl driver matches on interface descriptors (class=ff,
+        # subclass=00, protocol=00), so we check for that here
+        if _matches_udl_interface(device_path):
+            continue
+
+        product_name = _read_sysfs_value(
+            os.path.join(device_path, "product")
+        )
+
+        if product_name:
+            model = product_name
+        else:
+            model = "USB product {}".format(product_id.lower())
+
+        return {
+            "vendor": "DisplayLink",
+            "model": model,
+        }
+
+    return None
+
+
+def detect(apt_cache):
+    """Return package recommendation if a DisplayLink device is detected."""
+    del apt_cache
+
+    device = _detect_displaylink_device()
+    if device is None:
+        return None
+
+    return {
+        "packages": [DISPLAYLINK_DRIVER_PACKAGE],
+        "vendor": device["vendor"],
+        "model": device["model"],
+    }

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         ),
         ("/var/lib/ubuntu-drivers-common/", []),
         ("/usr/share/ubuntu-drivers-common/quirks", glob.glob("quirks/*")),
-        ("/usr/share/ubuntu-drivers-common/detect", glob.glob("detect-plugins/*")),
+        ("/usr/share/ubuntu-drivers-common/detect", [f for f in glob.glob("detect-plugins/*") if os.path.isfile(f)]),
         ("/usr/share/doc/ubuntu-drivers-common", ["README"]),
         ("/usr/lib/nvidia/", glob.glob("nvidia-installer-hooks/*")),
     ]

--- a/tests/test_ubuntu_drivers.py
+++ b/tests/test_ubuntu_drivers.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import shutil
 import logging
+import importlib.util
 
 # from gi.repository import GLib
 from gi.repository import UMockdev
@@ -37,6 +38,15 @@ APTDAEMON_LOG = False
 APTDAEMON_DEBUG = False
 
 dbus_address = None
+
+
+def load_detect_plugin(name):
+    """Load a detect plugin module from the detect-plugins/ source directory."""
+    path = os.path.join(ROOT_DIR, "detect-plugins", name + ".py")
+    spec = importlib.util.spec_from_file_location("dp_" + name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # modalias of an nvidia card covered by our nvidia-* packages
@@ -6398,6 +6408,105 @@ Description: broken \xEB encoding
             res["coreutils"], {"free": True, "from_distro": True, "plugin": "extra.py"}
         )
 
+    def test_system_driver_packages_detect_plugins_metadata(self):
+        """system_driver_packages() includes vendor/model metadata from plugins"""
+
+        with open(os.path.join(self.plugin_dir, "extra.py"), "w") as f:
+            f.write(
+                'def detect(apt): return {"packages": ["coreutils"], '
+                '"vendor": "Foo Inc", "model": "Bar 3000"}\n'
+            )
+
+        res = UbuntuDrivers.detect.system_driver_packages(
+            sys_path=self.umockdev.get_sys_dir()
+        )
+        self.assertTrue("coreutils" in res, list(res.keys()))
+        self.assertEqual(
+            res["coreutils"],
+            {
+                "free": True,
+                "from_distro": True,
+                "plugin": "extra.py",
+                "vendor": "Foo Inc",
+                "model": "Bar 3000",
+            },
+        )
+
+    def test_detect_plugin_packages_dict_metadata(self):
+        """detect_plugin_packages() collects vendor/model metadata"""
+
+        apt_pkg.init_config()
+        apt_pkg.init_system()
+        cache = apt_pkg.Cache(None)
+
+        with open(os.path.join(self.plugin_dir, "meta.py"), "w") as f:
+            f.write(
+                'def detect(apt): return {"packages": ["coreutils"], '
+                '"vendor": "Foo Inc", "model": "Bar 3000"}\n'
+            )
+
+        metadata = {}
+        res = UbuntuDrivers.detect.detect_plugin_packages(
+            cache, plugin_metadata=metadata
+        )
+        self.assertEqual(res, {"meta.py": ["coreutils"]})
+        self.assertEqual(
+            metadata, {"meta.py": {"vendor": "Foo Inc", "model": "Bar 3000"}}
+        )
+
+    def test_detect_plugin_packages_dedup_sorted(self):
+        """detect_plugin_packages() deduplicates and sorts package lists"""
+
+        apt_pkg.init_config()
+        apt_pkg.init_system()
+        cache = apt_pkg.Cache(None)
+
+        with open(os.path.join(self.plugin_dir, "dup.py"), "w") as f:
+            f.write('def detect(apt): return ["coreutils", "bash", "coreutils"]\n')
+
+        res = UbuntuDrivers.detect.detect_plugin_packages(cache)
+        self.assertEqual(res, {"dup.py": ["bash", "coreutils"]})
+
+    def test_detect_plugin_packages_invalid_metadata(self):
+        """detect_plugin_packages() validates the dict return format"""
+
+        apt_pkg.init_config()
+        apt_pkg.init_system()
+        cache = apt_pkg.Cache(None)
+
+        # non-string vendor -> whole plugin result is skipped
+        with open(os.path.join(self.plugin_dir, "badvendor.py"), "w") as f:
+            f.write(
+                'def detect(apt): return {"packages": ["coreutils"], "vendor": 1}\n'
+            )
+        # non-string model -> whole plugin result is skipped
+        with open(os.path.join(self.plugin_dir, "badmodel.py"), "w") as f:
+            f.write(
+                'def detect(apt): return {"packages": ["coreutils"], "model": []}\n'
+            )
+        # missing "packages" key -> not a list/set -> skipped
+        with open(os.path.join(self.plugin_dir, "nopackages.py"), "w") as f:
+            f.write('def detect(apt): return {"vendor": "Foo"}\n')
+        # non-string package name is skipped, valid packages are kept
+        with open(os.path.join(self.plugin_dir, "mixed.py"), "w") as f:
+            f.write('def detect(apt): return {"packages": ["coreutils", 5]}\n')
+
+        metadata = {}
+        # suppress logging the deliberate errors in our test plugins to stderr
+        logging.getLogger().setLevel(logging.CRITICAL)
+        try:
+            res = UbuntuDrivers.detect.detect_plugin_packages(
+                cache, plugin_metadata=metadata
+            )
+        finally:
+            logging.getLogger().setLevel(logging.INFO)
+
+        self.assertNotIn("badvendor.py", res)
+        self.assertNotIn("badmodel.py", res)
+        self.assertNotIn("nopackages.py", res)
+        self.assertEqual(res.get("mixed.py"), ["coreutils"])
+        self.assertEqual(metadata, {})
+
     def test_system_device_drivers_chroot(self):
         """system_device_drivers() for test package repository"""
 
@@ -8582,6 +8691,128 @@ class KernelDectionTest(unittest.TestCase):
             self.assertEqual(linux, "linux-oem-20.04")
         finally:
             chroot.remove()
+
+
+class DisplayLinkPluginTest(unittest.TestCase):
+    """Test the DisplayLink USB detection plugin"""
+
+    def setUp(self):
+        self.plugin = load_detect_plugin("displaylink")
+        self.sysfs = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.sysfs)
+
+    def _add_device(self, name, attrs, interfaces=None):
+        """Create a fake USB device directory in the temporary sysfs tree."""
+        dev = os.path.join(self.sysfs, name)
+        os.makedirs(dev)
+        for key, value in attrs.items():
+            with open(os.path.join(dev, key), "w") as f:
+                f.write(value + "\n")
+        for iface_name, iface_attrs in (interfaces or {}).items():
+            iface = os.path.join(dev, iface_name)
+            os.makedirs(iface)
+            for key, value in iface_attrs.items():
+                with open(os.path.join(iface, key), "w") as f:
+                    f.write(value + "\n")
+        return dev
+
+    def test_detect_displaylink_device(self):
+        """A DisplayLink device without a udl interface is detected"""
+
+        self._add_device(
+            "1-1",
+            {"idVendor": "17e9", "idProduct": "4301", "product": "Displaylink Universal Dock"},
+        )
+        res = self.plugin._detect_displaylink_device(sysfs_root=self.sysfs)
+        self.assertEqual(res, {"vendor": "DisplayLink", "model": "Displaylink Universal Dock"})
+
+    def test_udl_device_excluded(self):
+        """A device matching the in-kernel udl driver is not recommended"""
+
+        self._add_device(
+            "1-1",
+            {"idVendor": "17e9", "idProduct": "4301", "product": "Displaylink Universal Dock"},
+            interfaces={
+                "1-1:1.0": {
+                    "bInterfaceClass": "ff",
+                    "bInterfaceSubClass": "00",
+                    "bInterfaceProtocol": "00",
+                }
+            },
+        )
+        self.assertIsNone(
+            self.plugin._detect_displaylink_device(sysfs_root=self.sysfs)
+        )
+
+    def test_device_with_non_udl_interface_detected(self):
+        """A DisplayLink device with a non-matching interface is still detected"""
+
+        self._add_device(
+            "1-1",
+            {"idVendor": "17e9", "idProduct": "4301", "product": "Monitor"},
+            interfaces={
+                "1-1:1.0": {
+                    "bInterfaceClass": "ff",
+                    "bInterfaceSubClass": "01",
+                    "bInterfaceProtocol": "00",
+                }
+            },
+        )
+        res = self.plugin._detect_displaylink_device(sysfs_root=self.sysfs)
+        self.assertEqual(res, {"vendor": "DisplayLink", "model": "Monitor"})
+
+    def test_non_displaylink_vendor(self):
+        """Devices from other vendors are ignored"""
+
+        self._add_device("1-1", {"idVendor": "1234", "idProduct": "0001"})
+        self.assertIsNone(
+            self.plugin._detect_displaylink_device(sysfs_root=self.sysfs)
+        )
+
+    def test_model_fallback_to_product_id(self):
+        """The model falls back to the product id when no product name exists"""
+
+        self._add_device("1-1", {"idVendor": "17e9", "idProduct": "4A01"})
+        res = self.plugin._detect_displaylink_device(sysfs_root=self.sysfs)
+        self.assertEqual(
+            res, {"vendor": "DisplayLink", "model": "USB product 4a01"}
+        )
+
+    def test_missing_sysfs_root(self):
+        """A missing sysfs root does not raise and returns None"""
+
+        res = self.plugin._detect_displaylink_device(
+            sysfs_root=os.path.join(self.sysfs, "does-not-exist")
+        )
+        self.assertIsNone(res)
+
+    def test_detect_returns_package(self):
+        """detect() wraps a detected device into a package recommendation"""
+
+        with patch.object(
+            self.plugin,
+            "_detect_displaylink_device",
+            return_value={"vendor": "DisplayLink", "model": "Displaylink Universal Dock"},
+        ):
+            res = self.plugin.detect(None)
+        self.assertEqual(
+            res,
+            {
+                "packages": ["displaylink-driver"],
+                "vendor": "DisplayLink",
+                "model": "Displaylink Universal Dock",
+            },
+        )
+
+    def test_detect_no_device(self):
+        """detect() returns None when no DisplayLink device is present"""
+
+        with patch.object(
+            self.plugin, "_detect_displaylink_device", return_value=None
+        ):
+            self.assertIsNone(self.plugin.detect(None))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds detection of DisplayLink USB graphics devices and recommends the
`displaylink-driver` package when appropriate. To support this cleanly, the
detection-plugin API is extended so plugins can optionally report
human-readable `vendor`/`model` metadata, matching what is already available
for modalias-based driver detection.

## Changes

### DisplayLink detection plugin
- New `detect-plugins/displaylink.py` that scans USB sysfs
  (`/sys/bus/usb/devices`) for DisplayLink devices (USB vendor `17e9`).
- Devices already handled by the in-kernel `udl` DRM driver are **excluded**
  by inspecting USB interface descriptors (`bInterfaceClass=0xff`,
  `bInterfaceSubClass=0x00`, `bInterfaceProtocol=0x00`), mirroring the match
  logic in `drivers/gpu/drm/udl/udl_drv.c`. This avoids recommending the
  proprietary package for devices that already work with the open-source
  kernel driver.
- Falls back to a synthesized model name (`USB product <id>`) when the sysfs
  `product` attribute is unavailable.

### Plugin metadata support (`UbuntuDrivers/detect.py`)
- `detect_plugin_packages()` now accepts an optional `plugin_metadata`
  output dict and understands a new dictionary return format from plugins:
  a mandatory `packages` key plus optional `vendor` and `model` entries.
  The existing list/set return format remains fully supported.
- `system_driver_packages()` propagates plugin `vendor`/`model` into the
  resulting `PackageInfo`.
- Adds input validation for the dict format (type checks for `vendor`,
  `model`, and individual package names) and deduplicates/sorts plugin
  package results for deterministic output.

### Packaging fix (`setup.py`)
- Filters out directories when installing `detect-plugins/*`, so only files
  are shipped into `/usr/share/ubuntu-drivers-common/detect`.

### Tests & docs
- Adds tests covering the new dict return format (vendor/model collection,
  package dedup/sort, invalid vendor/model/package validation) and a
  `DisplayLinkPluginTest` exercising the plugin against a fake sysfs tree
  (device detection, `udl` exclusion, product-name fallback, non-matching
  vendors, and the `detect()` return contract).
- Documents the new dictionary plugin return format in the README.
- Adds a changelog entry (`1:0.10.10`).

## Backwards compatibility

The plugin return-type change is additive: existing plugins returning a
`list` or `set` continue to work unchanged, and the return type of
`detect_plugin_packages()` is preserved (`pluginname -> [package, ...]`).

## Manual tests

The ubuntu-drivers package was built on Ubuntu 24.04 and tested on Ubuntu 24.04 and 26.04.

<img width="312" height="88" alt="sc2" src="https://github.com/user-attachments/assets/3cdd165f-a32c-43d4-b1ce-4b1d93e338f5" />
<img width="581" height="366" alt="sc1" src="https://github.com/user-attachments/assets/6d1e5a04-a7c2-475f-a4be-85c117c10cfc" />

For proper detection of DisplayLink devices, there is a need to download the Synaptics APT Repository  (https://www.synaptics.com/products/displaylink-graphics/downloads/ubuntu) and then install it 
`sudo apt install ./Downloads/synaptics-repository-keyring.deb` 
Without it, ubuntu-drivers will not see the needed proprietary driver.
These steps are required as long as the Synaptics APT Repository is not added to the Ubuntu archive (multiverse).