### PR TITLE
Refuse to install on lxc containers unless specified

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-drivers-common (1:0.10.11) stonking; urgency=medium
+
+  * Refuse to install on lxc containers unless specified
+
+ -- Mitchell Augustin <mitchell.augustin@canonical.com>  Fri, 14 Aug 2026 16:28:22 -0500
+
 ubuntu-drivers-common (1:0.10.10) stonking; urgency=medium
 
   [ Ashton Nelson ]

--- a/ubuntu-drivers
+++ b/ubuntu-drivers
@@ -36,6 +36,14 @@ logger.setLevel(level=LOGLEVEL)
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
+LXC_INSTALL_WARNING = (
+    "You appear to be attempting to run ubuntu-drivers inside an LXC/LXD container. "
+    "This is not supported and may have undefined behavior. Instead, you should "
+    "refer to https://canonical.com/lxd/docs/latest/howto/container_gpu_passthrough_with_docker/ "
+    "for passthrough instructions that will expose your host driver stack. To "
+    "override this and install anyway, re-run with `--install-in-container-anyway`"
+)
+
 
 class Config(object):
     def __init__(self) -> None:
@@ -49,6 +57,21 @@ class Config(object):
 
 
 pass_config = click.make_pass_decorator(Config, ensure=True)
+
+
+def is_lxc_container() -> bool:
+    try:
+        result = subprocess.run(
+            ["systemd-detect-virt", "--container"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return False
+
+    return result.stdout.strip() == "lxc"
 
 
 def command_list(args: Config) -> int:
@@ -601,6 +624,11 @@ def greet(config: Config, **kwargs: Any) -> None:
     help="Do not include OEM enablement packages (these enable an external archive)",
 )
 @click.option("--include-dkms", is_flag=True, help="Also consider DKMS packages")
+@click.option(
+    "--install-in-container-anyway",
+    is_flag=True,
+    help="Allow driver installation inside an LXC container",
+)
 @pass_config
 def install(config: Config, **kwargs: Any) -> None:
     """Install a driver [driver[:version][,driver[:version]]]"""
@@ -611,6 +639,10 @@ def install(config: Config, **kwargs: Any) -> None:
             "Error: 'ubuntu-drivers install' must be run as root. Try using 'sudo'.",
             file=sys.stderr,
         )
+        sys.exit(1)
+
+    if is_lxc_container() and not kwargs.get("install_in_container_anyway"):
+        print(LXC_INSTALL_WARNING, file=sys.stderr)
         sys.exit(1)
 
     if kwargs.get("gpgpu"):


### PR DESCRIPTION
GPU driver installation behavior is undefined inside an LXC container. While it can sometimes end up working, it usually tries to pull various kernel and firmware dependencies that will throw apt errors when attempting to install to paths that are owned by the host. It may also install a userspace that mismatches the kernel module versions on the host system, which will not work.

The correct way to run GPU applications inside of an LXC container is by passing the GPU to the container with the container-device interface semantics, as described in the LXC docs. u-d-c should fail to run by default in an lxc container environment and point users there.