### PR TITLE
feat: Surface open_preferred through the dbus service

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for automatic installation.
 
 The three main functions are:
 
-1. Which driver packages apply to this system?  
+1. Which driver packages apply to this system?
 
    `packages = UbuntuDrivers.detect.system_driver_packages()`
 
@@ -80,6 +80,7 @@ The returned structure is a list of dictionaries like:
             "builtin": False,
             "recommended": True,
             "support": "PB",
+            "open_preferred": False,
          },
          ...
       ],
@@ -90,7 +91,9 @@ The returned structure is a list of dictionaries like:
 
 `source` is either `"distro"` or `"third-party"`, and `support` carries the
 package's apt `Support` field (`"PB"`, `"NFB"`, `"LTSB"` or `"Legacy"`), empty
-when the package does not declare one.
+when the package does not declare one. `open_preferred` is `True` when Ubuntu's
+driver-selection logic prefers the "open" kernel module variant over the
+closed-source variant for this driver.
 
 The D-Bus service implementation lives in
 `UbuntuDrivers/service/drivers_service.py`. It is activated on demand by

--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -31,6 +31,7 @@ class DriverInfo(TypedDict, total=False):
     from_distro: bool
     recommended: bool
     support: Optional[str]
+    open_preferred: bool
 
 
 class DeviceInfo(TypedDict, total=False):
@@ -1110,6 +1111,9 @@ def system_device_drivers(
                      recommended == True, and all others False.
       'support':     Value of the package's apt "Support" field ("PB", "NFB",
                      "LTSB" or "Legacy"), or None if it declares none.
+      'open_preferred': Boolean flag whether the "open" kernel module variant
+                     is preferred over the closed one for this package, per
+                     _is_open_prefered().
     """
     result: Dict[str, DeviceInfo] = {}
     if not apt_cache:
@@ -1137,6 +1141,8 @@ def system_device_drivers(
             drivers[pkg]["recommended"] = pkginfo["recommended"]
         if "support" in pkginfo:
             drivers[pkg]["support"] = pkginfo["support"]
+        if "open_preferred" in pkginfo:
+            drivers[pkg]["open_preferred"] = pkginfo["open_preferred"]
 
     # now determine the manual_install device flag: this is true iff all driver
     # packages are "manually installed"

--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -683,7 +683,7 @@ def _get_db_name(syspath: str, alias: str) -> Tuple[Optional[str], Optional[str]
     return (vendor, model)
 
 
-def _is_open_prefered(apt_cache: apt_pkg.Cache, pkg: apt_pkg.Package) -> bool:
+def _is_open_preferred(apt_cache: apt_pkg.Cache, pkg: apt_pkg.Package) -> bool:
     if not pkg.name.startswith("nvidia-"):
         return False
 
@@ -691,13 +691,13 @@ def _is_open_prefered(apt_cache: apt_pkg.Cache, pkg: apt_pkg.Package) -> bool:
     if preference is None:
         nvidia_info = NvidiaPkgNameInfo(pkg.name)
         if nvidia_info.get_major_version() >= 560:
-            logging.debug("_is_open_prefered(%s): True", pkg.name)
+            logging.debug("_is_open_preferred(%s): True", pkg.name)
             return True
     elif preference == "Open":
-        logging.debug("_is_open_prefered(%s): True", pkg.name)
+        logging.debug("_is_open_preferred(%s): True", pkg.name)
         return True
 
-    logging.debug("_is_open_prefered(%s): False", pkg.name)
+    logging.debug("_is_open_preferred(%s): False", pkg.name)
     return False
 
 
@@ -779,7 +779,7 @@ def system_driver_packages(
                 "from_distro": _is_package_from_distro(apt_cache, p),
                 "support": _pkg_get_support(apt_cache, p),
                 "runtimepm": _is_runtimepm_supported(apt_cache, p, alias),
-                "open_preferred": _is_open_prefered(apt_cache, p),
+                "open_preferred": _is_open_preferred(apt_cache, p),
             }
             (vendor, model) = _get_db_name(syspath, alias)
             if vendor is not None:
@@ -962,7 +962,7 @@ def system_device_specific_metapackages(
                 "from_distro": _is_package_from_distro(apt_cache, p),
                 "recommended": True,
                 "support": _pkg_get_support(apt_cache, p),
-                "open_preferred": _is_open_prefered(apt_cache, p),
+                "open_preferred": _is_open_preferred(apt_cache, p),
             }
 
     return packages
@@ -1026,7 +1026,7 @@ def system_gpgpu_driver_packages(
                     "free": _is_package_free(apt_cache, p),
                     "from_distro": _is_package_from_distro(apt_cache, p),
                     "support": _pkg_get_support(apt_cache, p),
-                    "open_preferred": _is_open_prefered(apt_cache, p),
+                    "open_preferred": _is_open_preferred(apt_cache, p),
                 }
                 if vendor is not None:
                     packages[p.name]["vendor"] = vendor
@@ -1113,7 +1113,7 @@ def system_device_drivers(
                      "LTSB" or "Legacy"), or None if it declares none.
       'open_preferred': Boolean flag whether the "open" kernel module variant
                      is preferred over the closed one for this package, per
-                     _is_open_prefered().
+                     _is_open_preferred().
     """
     result: Dict[str, DeviceInfo] = {}
     if not apt_cache:

--- a/UbuntuDrivers/service/drivers_service.py
+++ b/UbuntuDrivers/service/drivers_service.py
@@ -66,6 +66,8 @@ def _build_drivers_variant() -> GLib.Variant:
         builtin     b   whether the driver is built into the kernel
         recommended b   whether this is the recommended driver
         support     s   apt Support field value (e.g. "PB"), empty if absent
+        open_preferred b   whether the "open" kernel module variant is
+                           preferred over the closed one for this driver
 
     Raises:
         RuntimeError: if the apt cache cannot be initialized.
@@ -107,6 +109,9 @@ def _build_drivers_variant() -> GLib.Variant:
                             "b", bool(pkg_info.get("recommended", False))
                         ),
                         "support": GLib.Variant("s", pkg_info.get("support") or ""),
+                        "open_preferred": GLib.Variant(
+                            "b", bool(pkg_info.get("open_preferred", False))
+                        ),
                     },
                 )
             )

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-drivers-common (1:0.10.11ubuntu1) UNRELEASED; urgency=medium
+
+  * Add open_preferred to dbus output
+
+ -- ashton.nelson@canonical.com <ashton.nelson@canonical.com>  Wed, 26 Aug 2026 14:31:39 -0500
+
 ubuntu-drivers-common (1:0.10.11) stonking; urgency=medium
 
   * Refuse to install on lxc containers unless specified

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-ubuntu-drivers-common (1:0.10.11ubuntu1) UNRELEASED; urgency=medium
-
-  * Add open_preferred to dbus output
-
- -- ashton.nelson@canonical.com <ashton.nelson@canonical.com>  Wed, 26 Aug 2026 14:31:39 -0500
-
 ubuntu-drivers-common (1:0.10.11) stonking; urgency=medium
 
   * Refuse to install on lxc containers unless specified

--- a/tests/test_drivers_service.py
+++ b/tests/test_drivers_service.py
@@ -144,6 +144,14 @@ def gen_fakearchive():
             "Modaliases": "nv(pci:v000010DEd000010C3sv*sd*bc03sc*i*)",
         },
     )
+    a.create_deb(
+        "nvidia-driver-350",
+        dependencies={"Depends": "xorg-video-abi-4"},
+        extra_tags={
+            "Modaliases": "nv(pci:v000010DEd000010C3sv*sd*bc03sc*i*)",
+            "Prefer-Variant": "Open",
+        },
+    )
     return a
 
 
@@ -445,6 +453,7 @@ class DriversServiceDbusTests(unittest.TestCase):
         self.assertFalse(recommended["builtin"])
         self.assertEqual(recommended["source"], "distro")
         self.assertEqual(recommended["support"], "PB")
+        self.assertFalse(recommended["open_preferred"])
 
         non_recommended = by_name["nvidia-driver-390"]
         self.assertFalse(non_recommended["recommended"])
@@ -452,6 +461,15 @@ class DriversServiceDbusTests(unittest.TestCase):
         self.assertFalse(non_recommended["builtin"])
         self.assertEqual(non_recommended["source"], "distro")
         self.assertEqual(non_recommended["support"], "")
+        self.assertFalse(non_recommended["open_preferred"])
+
+        prefers_open = by_name["nvidia-driver-350"]
+        self.assertFalse(prefers_open["recommended"])
+        self.assertFalse(prefers_open["free"])
+        self.assertFalse(prefers_open["builtin"])
+        self.assertEqual(prefers_open["source"], "distro")
+        self.assertEqual(prefers_open["support"], "")
+        self.assertTrue(prefers_open["open_preferred"])
 
     def test_dbus_drivers_nouveau_attributes(self):
         """Built-in free driver (nouveau) attributes are mapped correctly."""

--- a/tests/test_ubuntu_drivers.py
+++ b/tests/test_ubuntu_drivers.py
@@ -6458,7 +6458,12 @@ Description: broken \xEB encoding
             {
                 "modalias": "pci:v00001234d00sv00000001sd00bc00sc00i00",
                 "drivers": {
-                    "vanilla": {"free": True, "from_distro": False, "support": None}
+                    "vanilla": {
+                        "free": True,
+                        "from_distro": False,
+                        "support": None,
+                        "open_preferred": False,
+                    }
                 },
             },
         )
@@ -6468,7 +6473,12 @@ Description: broken \xEB encoding
             {
                 "modalias": "usb:v9876dABCDsv01sd02bc00sc01i05",
                 "drivers": {
-                    "chocolate": {"free": True, "from_distro": False, "support": None}
+                    "chocolate": {
+                        "free": True,
+                        "from_distro": False,
+                        "support": None,
+                        "open_preferred": False,
+                    }
                 },
             },
         )
@@ -6480,7 +6490,13 @@ Description: broken \xEB encoding
         # should contain nouveau driver
         self.assertEqual(
             graphics_dict["drivers"]["nvidia-driver-450"],
-            {"free": False, "from_distro": False, "recommended": True, "support": None},
+            {
+                "free": False,
+                "from_distro": False,
+                "recommended": True,
+                "support": None,
+                "open_preferred": False,
+            },
         )
         self.assertEqual(
             graphics_dict["drivers"]["nvidia-driver-440"],
@@ -6489,6 +6505,7 @@ Description: broken \xEB encoding
                 "from_distro": False,
                 "recommended": False,
                 "support": None,
+                "open_preferred": False,
             },
         )
         self.assertEqual(
@@ -6498,6 +6515,7 @@ Description: broken \xEB encoding
                 "from_distro": False,
                 "recommended": False,
                 "support": None,
+                "open_preferred": False,
             },
         )
         self.assertEqual(


### PR DESCRIPTION
Passes the `open_preferred` field through to the output of drivers for the dbus service. This allows consumers to determine whether open is preferred for certain nvidia drivers, and avoid having to duplicate the logic `ubuntu-drivers-common` already provides.

Alternatively I considered passing the actual string of the field (e.g. "Open", "Closed"), but seeing as `open_preferred` as a bool is used elsewhere, I opted for that.

Related to https://github.com/canonical/ubuntu-drivers-common/pull/175

---

UDENG-11308