### PR TITLE
feat: Add extra_packages field to dbus output

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The returned structure is a list of dictionaries like:
             "recommended": True,
             "support": "PB",
             "open_preferred": False,
+            "extra_packages": ["linux-modules-nvidia-570-generic"],
          },
          ...
       ],
@@ -94,6 +95,11 @@ package's apt `Support` field (`"PB"`, `"NFB"`, `"LTSB"` or `"Legacy"`), empty
 when the package does not declare one. `open_preferred` is `True` when Ubuntu's
 driver-selection logic prefers the "open" kernel module variant over the
 closed-source variant for this driver.
+
+`extra_packages` lists additional packages that should be installed
+alongside this driver (e.g. its kernel modules package), beyond its
+ordinary apt dependencies. Not filtered down to only what is not yet
+installed.
 
 The D-Bus service implementation lives in
 `UbuntuDrivers/service/drivers_service.py`. It is activated on demand by

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The returned structure is a list of dictionaries like:
             "recommended": True,
             "support": "PB",
             "open_preferred": False,
-            "extra_packages": ["linux-modules-nvidia-570-generic"],
+            "packages": ["nvidia-driver-570", "linux-modules-nvidia-570-generic"],
+            "gpgpu_packages": ["nvidia-headless-no-dkms-570", "linux-modules-nvidia-570-generic"],
          },
          ...
       ],
@@ -96,10 +97,10 @@ when the package does not declare one. `open_preferred` is `True` when Ubuntu's
 driver-selection logic prefers the "open" kernel module variant over the
 closed-source variant for this driver.
 
-`extra_packages` lists additional packages that should be installed
-alongside this driver (e.g. its kernel modules package), beyond its
-ordinary apt dependencies. Not filtered down to only what is not yet
-installed.
+`packages` is what `ubuntu-drivers install <name>` would install for this
+driver: the complete install set, not filtered by installed state.
+`gpgpu_packages` is the equivalent for `ubuntu-drivers install --gpgpu
+<name>`. Either list may be empty when the driver would require DKMS.
 
 The D-Bus service implementation lives in
 `UbuntuDrivers/service/drivers_service.py`. It is activated on demand by

--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -32,6 +32,7 @@ class DriverInfo(TypedDict, total=False):
     recommended: bool
     support: Optional[str]
     open_preferred: bool
+    metapackage: str
 
 
 class DeviceInfo(TypedDict, total=False):
@@ -1114,6 +1115,8 @@ def system_device_drivers(
       'open_preferred': Boolean flag whether the "open" kernel module variant
                      is preferred over the closed one for this package, per
                      _is_open_preferred().
+      'metapackage': Name of the associated metapackage (e.g.
+                     "nvidia-headless-no-dkms-470"), if any.
     """
     result: Dict[str, DeviceInfo] = {}
     if not apt_cache:
@@ -1143,6 +1146,8 @@ def system_device_drivers(
             drivers[pkg]["support"] = pkginfo["support"]
         if "open_preferred" in pkginfo:
             drivers[pkg]["open_preferred"] = pkginfo["open_preferred"]
+        if "metapackage" in pkginfo:
+            drivers[pkg]["metapackage"] = pkginfo["metapackage"]
 
     # now determine the manual_install device flag: this is true iff all driver
     # packages are "manually installed"

--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -1310,6 +1310,7 @@ def _build_installation_list(
     include_dkms: bool,
     gpgpu: bool = False,
     filter_installed: bool = True,
+    skip_runtimepm_marker: bool = False,
 ) -> List[str]:
     """
     Build the list of packages to install including metapackages and modules.
@@ -1326,6 +1327,8 @@ def _build_installation_list(
             modules/lrm-meta "already installed" check below no longer
             prevents driver_found from being set, so the loop still stops at
             the first resolved driver (aside from hwe- metas).
+        skip_runtimepm_marker: Boolean, if True, skip creating
+            /run/nvidia_runtimepm_supported
 
     Returns:
         List of package names to install including metapackages and module packages.
@@ -1342,7 +1345,7 @@ def _build_installation_list(
         if not p.startswith("hwe-") and driver_found:
             continue
 
-        if not gpgpu:
+        if not gpgpu and not skip_runtimepm_marker:
             candidate_ver = depcache.get_candidate_ver(cache[p])
             records = apt_pkg.PackageRecords(cache)
             records.lookup(candidate_ver.file_list[0])
@@ -1436,6 +1439,7 @@ def already_installed_filter(
     include_dkms: bool,
     gpgpu: bool = False,
     filter_installed: bool = True,
+    skip_runtimepm_marker: bool = False,
 ) -> List[str]:
     """
     Sort driver branch to install according to preference, then select
@@ -1451,6 +1455,8 @@ def already_installed_filter(
         filter_installed: Boolean, if False, the returned list is the
             complete install set rather than only the subset not yet
             installed.
+        skip_runtimepm_marker: Boolean, if True, suppress side effects of computing
+            the install set.
 
     Takes a list of packages of this format:
     {'modalias': 'pci:v000010DEd000010C3sv00003842sd00002670bc03sc03i00',
@@ -1485,7 +1491,12 @@ def already_installed_filter(
 
     # Step 2: Build the installation list with metapackages and modules
     to_install = _build_installation_list(
-        cache, sorted_packages, include_dkms, gpgpu, filter_installed
+        cache,
+        sorted_packages,
+        include_dkms,
+        gpgpu,
+        filter_installed,
+        skip_runtimepm_marker,
     )
 
     # Step 3: Filter out already installed packages
@@ -1504,6 +1515,7 @@ def gpgpu_install_filter(
     get_recommended: bool = True,
     gpgpu: bool = True,
     filter_installed: bool = True,
+    skip_runtimepm_marker: bool = False,
 ) -> List[str]:
     drivers: List[_GpgpuDriver] = []
     allow: List[str] = []
@@ -1524,6 +1536,8 @@ def gpgpu_install_filter(
         filter_installed: Boolean, if False, the returned list is the
             complete install set rather than only the subset not yet
             installed.
+        skip_runtimepm_marker: Boolean, if True, suppress side effects of computing
+            the install set.
 
     Returns:
         A list of drivers to be installed, of the form
@@ -1626,7 +1640,7 @@ def gpgpu_install_filter(
                         # print('Found "recommended" flavour in %s' % (packages[p]))
                 break
     return already_installed_filter(
-        cache, result, include_dkms, gpgpu, filter_installed
+        cache, result, include_dkms, gpgpu, filter_installed, skip_runtimepm_marker
     )
 
 
@@ -1638,6 +1652,7 @@ def auto_install_filter(
     get_recommended: bool = True,
     gpgpu: bool = False,
     filter_installed: bool = True,
+    skip_runtimepm_marker: bool = False,
 ) -> List[str]:
     """
     Get packages which are appropriate for automatic installation.
@@ -1654,6 +1669,8 @@ def auto_install_filter(
         filter_installed: Boolean, if False, the returned list is the
             complete install set rather than only the subset not yet
             installed.
+        skip_runtimepm_marker: Boolean, if True, suppress side effects of computing
+            the install set.
 
     Returns:
         The subset of the given list of packages which are appropriate for
@@ -1684,6 +1701,7 @@ def auto_install_filter(
             True,
             gpgpu,
             filter_installed=filter_installed,
+            skip_runtimepm_marker=skip_runtimepm_marker,
         )
         return results
 
@@ -1699,7 +1717,7 @@ def auto_install_filter(
         else:
             result[p] = packages[p]
     return already_installed_filter(
-        cache, result, include_dkms, gpgpu, filter_installed
+        cache, result, include_dkms, gpgpu, filter_installed, skip_runtimepm_marker
     )
 
 

--- a/UbuntuDrivers/detect.py
+++ b/UbuntuDrivers/detect.py
@@ -32,7 +32,6 @@ class DriverInfo(TypedDict, total=False):
     recommended: bool
     support: Optional[str]
     open_preferred: bool
-    metapackage: str
 
 
 class DeviceInfo(TypedDict, total=False):
@@ -1115,8 +1114,6 @@ def system_device_drivers(
       'open_preferred': Boolean flag whether the "open" kernel module variant
                      is preferred over the closed one for this package, per
                      _is_open_preferred().
-      'metapackage': Name of the associated metapackage (e.g.
-                     "nvidia-headless-no-dkms-470"), if any.
     """
     result: Dict[str, DeviceInfo] = {}
     if not apt_cache:
@@ -1146,8 +1143,6 @@ def system_device_drivers(
             drivers[pkg]["support"] = pkginfo["support"]
         if "open_preferred" in pkginfo:
             drivers[pkg]["open_preferred"] = pkginfo["open_preferred"]
-        if "metapackage" in pkginfo:
-            drivers[pkg]["metapackage"] = pkginfo["metapackage"]
 
     # now determine the manual_install device flag: this is true iff all driver
     # packages are "manually installed"
@@ -1236,7 +1231,6 @@ def nvidia_desktop_post_installation_hook() -> None:
 
 
 class _GpgpuDriver(object):
-
     def __init__(
         self, vendor: Optional[str] = None, flavour: Optional[str] = None
     ) -> None:
@@ -1315,6 +1309,7 @@ def _build_installation_list(
     sorted_packages: List[Tuple[str, PackageInfo]],
     include_dkms: bool,
     gpgpu: bool = False,
+    filter_installed: bool = True,
 ) -> List[str]:
     """
     Build the list of packages to install including metapackages and modules.
@@ -1324,6 +1319,13 @@ def _build_installation_list(
         sorted_packages: List of (package_name, package_info) tuples sorted by preference.
         include_dkms: Boolean indicating whether to include DKMS packages.
         gpgpu: Boolean flag indicating whether to use GPGPU (server) mode.
+        filter_installed: Boolean, if False, currently-installed metapackages
+            and modules packages no longer short-circuit the loop, so the
+            returned list reflects the complete install set rather than only
+            what is not yet installed. With filter_installed=False, the
+            modules/lrm-meta "already installed" check below no longer
+            prevents driver_found from being set, so the loop still stops at
+            the first resolved driver (aside from hwe- metas).
 
     Returns:
         List of package names to install including metapackages and module packages.
@@ -1363,7 +1365,7 @@ def _build_installation_list(
                 continue
 
         if candidate:
-            if cache[candidate].current_ver:
+            if filter_installed and cache[candidate].current_ver:
                 to_install = []
                 driver_found = True
                 continue
@@ -1378,7 +1380,9 @@ def _build_installation_list(
         # Add the matching linux modules package
         modules_package = get_linux_modules_metapackage(cache, p)
         logging.debug(modules_package)
-        if modules_package and not cache[modules_package].current_ver:
+        if modules_package and not (
+            filter_installed and cache[modules_package].current_ver
+        ):
             if not include_dkms and "dkms" in modules_package:
                 if p in to_install:
                     to_install.remove(p)
@@ -1393,7 +1397,7 @@ def _build_installation_list(
             to_install.append(modules_package)
 
             lrm_meta = get_userspace_lrm_meta(cache, p)
-            if lrm_meta and not cache[lrm_meta].current_ver:
+            if lrm_meta and not (filter_installed and cache[lrm_meta].current_ver):
                 # Add the lrm meta and drop the non lrm one
                 to_install.append(lrm_meta)
                 if p in to_install and gpgpu:
@@ -1431,6 +1435,7 @@ def already_installed_filter(
     packages: Dict[str, PackageInfo],
     include_dkms: bool,
     gpgpu: bool = False,
+    filter_installed: bool = True,
 ) -> List[str]:
     """
     Sort driver branch to install according to preference, then select
@@ -1443,6 +1448,9 @@ def already_installed_filter(
             and is filtered depending on the mode (desktop vs gpgpu) and user preferences.
         include_dkms: Boolean indicating whether to include DKMS packages.
         gpgpu: Boolean flag indicating whether to use GPGPU (server) sorting preferences.
+        filter_installed: Boolean, if False, the returned list is the
+            complete install set rather than only the subset not yet
+            installed.
 
     Takes a list of packages of this format:
     {'modalias': 'pci:v000010DEd000010C3sv00003842sd00002670bc03sc03i00',
@@ -1476,10 +1484,13 @@ def already_installed_filter(
     sorted_packages = _sort_packages_by_preference(packages, gpgpu)
 
     # Step 2: Build the installation list with metapackages and modules
-    to_install = _build_installation_list(cache, sorted_packages, include_dkms, gpgpu)
+    to_install = _build_installation_list(
+        cache, sorted_packages, include_dkms, gpgpu, filter_installed
+    )
 
     # Step 3: Filter out already installed packages
-    to_install = _remove_already_installed(cache, to_install)
+    if filter_installed:
+        to_install = _remove_already_installed(cache, to_install)
 
     logging.debug("to_install_final:  " + str(to_install))
     return to_install
@@ -1492,6 +1503,7 @@ def gpgpu_install_filter(
     drivers_str: str,
     get_recommended: bool = True,
     gpgpu: bool = True,
+    filter_installed: bool = True,
 ) -> List[str]:
     drivers: List[_GpgpuDriver] = []
     allow: List[str] = []
@@ -1509,6 +1521,9 @@ def gpgpu_install_filter(
         drivers_str: String specifying driver(s) and version(s) to filter for.
         get_recommended: Boolean, if True only recommended packages are considered.
         gpgpu: Boolean flag indicating whether to use GPGPU (server) sorting preferences.
+        filter_installed: Boolean, if False, the returned list is the
+            complete install set rather than only the subset not yet
+            installed.
 
     Returns:
         A list of drivers to be installed, of the form
@@ -1610,7 +1625,9 @@ def gpgpu_install_filter(
                         result[p] = packages[p]
                         # print('Found "recommended" flavour in %s' % (packages[p]))
                 break
-    return already_installed_filter(cache, result, include_dkms, gpgpu)
+    return already_installed_filter(
+        cache, result, include_dkms, gpgpu, filter_installed
+    )
 
 
 def auto_install_filter(
@@ -1620,6 +1637,7 @@ def auto_install_filter(
     drivers_str: str = "",
     get_recommended: bool = True,
     gpgpu: bool = False,
+    filter_installed: bool = True,
 ) -> List[str]:
     """
     Get packages which are appropriate for automatic installation.
@@ -1633,6 +1651,9 @@ def auto_install_filter(
         drivers_str: String specifying driver(s) and version(s) to filter for (optional).
         get_recommended: Boolean, if True only recommended packages are considered.
         gpgpu: Boolean flag indicating whether to use GPGPU (server) sorting preferences.
+        filter_installed: Boolean, if False, the returned list is the
+            complete install set rather than only the subset not yet
+            installed.
 
     Returns:
         The subset of the given list of packages which are appropriate for
@@ -1656,7 +1677,13 @@ def auto_install_filter(
     # If users specify a driver, use gpgpu_install_filter()
     if drivers_str:
         results = gpgpu_install_filter(
-            cache, include_dkms, packages, drivers_str, True, gpgpu
+            cache,
+            include_dkms,
+            packages,
+            drivers_str,
+            True,
+            gpgpu,
+            filter_installed=filter_installed,
         )
         return results
 
@@ -1671,7 +1698,9 @@ def auto_install_filter(
                 result[p] = packages[p]
         else:
             result[p] = packages[p]
-    return already_installed_filter(cache, result, include_dkms, gpgpu)
+    return already_installed_filter(
+        cache, result, include_dkms, gpgpu, filter_installed
+    )
 
 
 def detect_plugin_packages(

--- a/UbuntuDrivers/service/drivers_service.py
+++ b/UbuntuDrivers/service/drivers_service.py
@@ -184,7 +184,8 @@ def _build_drivers_variant() -> GLib.Variant:
                         ),
                         "support": GLib.Variant("s", pkg_info.get("support") or ""),
                         "open_preferred": GLib.Variant(
-                            "b", bool(pkg_info.get("open_preferred", False))),
+                            "b", bool(pkg_info.get("open_preferred", False))
+                        ),
                         "packages": GLib.Variant("as", packages),
                         "gpgpu_packages": GLib.Variant("as", gpgpu_packages),
                     },

--- a/UbuntuDrivers/service/drivers_service.py
+++ b/UbuntuDrivers/service/drivers_service.py
@@ -8,6 +8,7 @@ import sys
 from typing import Callable, List, Optional
 
 import UbuntuDrivers.detect
+from UbuntuDrivers.detect import DriverInfo
 
 import apt_pkg
 from gi.repository import Gio, GLib
@@ -45,6 +46,43 @@ def _dbus_error_name(domain: str) -> str:
     return _ERROR_FAILED
 
 
+def _extra_packages(
+    cache: apt_pkg.Cache, pkg_name: str, pkg_info: DriverInfo
+) -> List[str]:
+    """Return additional packages that should be installed alongside
+    *pkg_name*, beyond its ordinary apt dependencies: its kernel modules or
+    DKMS package, its LRM userspace package, and its GPGPU/headless
+    metapackage, if any of these apply.
+
+    Duplicates and unavailable entries are removed. Reports what
+    the driver requires regardless of what is already installed.
+    """
+    extras: List[str] = []
+
+    metapackage = pkg_info.get("metapackage")
+    if metapackage:
+        extras.append(metapackage)
+
+    modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(
+        cache, pkg_name
+    )
+    if modules_package:
+        extras.append(modules_package)
+
+    lrm_meta = UbuntuDrivers.detect.get_userspace_lrm_meta(cache, pkg_name)
+    if lrm_meta:
+        extras.append(lrm_meta)
+
+    # De-duplicate while preserving order.
+    seen = set()
+    result = []
+    for pkg in extras:
+        if pkg not in seen:
+            seen.add(pkg)
+            result.append(pkg)
+    return result
+
+
 def _build_drivers_variant() -> GLib.Variant:
     """Build the driver list as a D-Bus ``(aa{sv})`` GLib.Variant.
 
@@ -68,6 +106,13 @@ def _build_drivers_variant() -> GLib.Variant:
         support     s   apt Support field value (e.g. "PB"), empty if absent
         open_preferred b   whether the "open" kernel module variant is
                            preferred over the closed one for this driver
+        extra_packages
+                    as  additional packages to install alongside this
+                        driver (e.g. its kernel modules package), beyond
+                        its ordinary apt dependencies. See
+                        ``_extra_packages()`` for details. Reflects what
+                        the driver requires regardless of what is already
+                        installed.
 
     Raises:
         RuntimeError: if the apt cache cannot be initialized.
@@ -110,7 +155,9 @@ def _build_drivers_variant() -> GLib.Variant:
                         ),
                         "support": GLib.Variant("s", pkg_info.get("support") or ""),
                         "open_preferred": GLib.Variant(
-                            "b", bool(pkg_info.get("open_preferred", False))
+                            "b", bool(pkg_info.get("open_preferred", False))),
+                        "extra_packages": GLib.Variant(
+                            "as", _extra_packages(cache, pkg_name, pkg_info)
                         ),
                     },
                 )

--- a/UbuntuDrivers/service/drivers_service.py
+++ b/UbuntuDrivers/service/drivers_service.py
@@ -97,6 +97,7 @@ def _package_lists(
     packages = _install_list(cache, pkg_name, desktop_catalog, gpgpu=False)
     gpgpu_packages = _install_list(cache, pkg_name, gpgpu_catalog, gpgpu=True)
 
+    # Ensure `pkg_name` is included in the returned lists for non-nvidia drivers
     if not NvidiaPkgNameInfo(pkg_name).is_valid:
         if not packages and pkg_name in desktop_catalog:
             packages = [pkg_name]

--- a/UbuntuDrivers/service/drivers_service.py
+++ b/UbuntuDrivers/service/drivers_service.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 import signal
 import sys
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 import UbuntuDrivers.detect
-from UbuntuDrivers.detect import DriverInfo
+from UbuntuDrivers.detect import NvidiaPkgNameInfo, PackageInfo
 
 import apt_pkg
 from gi.repository import Gio, GLib
@@ -25,6 +25,9 @@ DEFAULT_IDLE_TIMEOUT_SECONDS = 300
 # D-Bus error names returned by drivers().
 _ERROR_CACHE_FAILURE = "com.ubuntu.Drivers.Error.CacheFailure"
 _ERROR_FAILED = "com.ubuntu.Drivers.Error.Failed"
+
+# Matches the "ubuntu-drivers install" CLI default.
+_INCLUDE_DKMS = False
 
 # gi ships no type information, so GLib.SOURCE_REMOVE is Any and returning it
 # straight from a "-> bool" callback trips mypy's warn_return_any.  Binding it
@@ -46,41 +49,59 @@ def _dbus_error_name(domain: str) -> str:
     return _ERROR_FAILED
 
 
-def _extra_packages(
-    cache: apt_pkg.Cache, pkg_name: str, pkg_info: DriverInfo
+def _install_list(
+    cache: apt_pkg.Cache,
+    pkg_name: str,
+    catalog: Dict[str, PackageInfo],
+    gpgpu: bool,
 ) -> List[str]:
-    """Return additional packages that should be installed alongside
-    *pkg_name*, beyond its ordinary apt dependencies: its kernel modules or
-    DKMS package, its LRM userspace package, and its GPGPU/headless
-    metapackage, if any of these apply.
-
-    Duplicates and unavailable entries are removed. Reports what
-    the driver requires regardless of what is already installed.
+    """Return the packages that ``ubuntu-drivers install`` (or, when *gpgpu*
+    is set, ``ubuntu-drivers install --gpgpu``) would install for *pkg_name*.
+    This is the complete install set, even packages already installed.
     """
-    extras: List[str] = []
+    if pkg_name not in catalog:
+        return []
 
-    metapackage = pkg_info.get("metapackage")
-    if metapackage:
-        extras.append(metapackage)
+    if gpgpu:
+        return UbuntuDrivers.detect.gpgpu_install_filter(
+            cache,
+            _INCLUDE_DKMS,
+            catalog,
+            pkg_name,
+            get_recommended=False,
+            filter_installed=False,
+        )
 
-    modules_package = UbuntuDrivers.detect.get_linux_modules_metapackage(
-        cache, pkg_name
+    return UbuntuDrivers.detect.auto_install_filter(
+        cache,
+        _INCLUDE_DKMS,
+        catalog,
+        pkg_name,
+        get_recommended=False,
+        filter_installed=False,
     )
-    if modules_package:
-        extras.append(modules_package)
 
-    lrm_meta = UbuntuDrivers.detect.get_userspace_lrm_meta(cache, pkg_name)
-    if lrm_meta:
-        extras.append(lrm_meta)
 
-    # De-duplicate while preserving order.
-    seen = set()
-    result = []
-    for pkg in extras:
-        if pkg not in seen:
-            seen.add(pkg)
-            result.append(pkg)
-    return result
+def _package_lists(
+    cache: apt_pkg.Cache,
+    pkg_name: str,
+    desktop_catalog: Dict[str, PackageInfo],
+    gpgpu_catalog: Dict[str, PackageInfo],
+) -> Tuple[List[str], List[str]]:
+    """Return ``(packages, gpgpu_packages)`` for *pkg_name*: the install
+    lists that ``ubuntu-drivers install <pkg_name>`` and
+    ``ubuntu-drivers install --gpgpu <pkg_name>`` would each produce.
+    """
+    packages = _install_list(cache, pkg_name, desktop_catalog, gpgpu=False)
+    gpgpu_packages = _install_list(cache, pkg_name, gpgpu_catalog, gpgpu=True)
+
+    if not NvidiaPkgNameInfo(pkg_name).is_valid:
+        if not packages and pkg_name in desktop_catalog:
+            packages = [pkg_name]
+        if not gpgpu_packages and pkg_name in gpgpu_catalog:
+            gpgpu_packages = [pkg_name]
+
+    return packages, gpgpu_packages
 
 
 def _build_drivers_variant() -> GLib.Variant:
@@ -106,13 +127,11 @@ def _build_drivers_variant() -> GLib.Variant:
         support     s   apt Support field value (e.g. "PB"), empty if absent
         open_preferred b   whether the "open" kernel module variant is
                            preferred over the closed one for this driver
-        extra_packages
-                    as  additional packages to install alongside this
-                        driver (e.g. its kernel modules package), beyond
-                        its ordinary apt dependencies. See
-                        ``_extra_packages()`` for details. Reflects what
-                        the driver requires regardless of what is already
-                        installed.
+        packages    as  what ``ubuntu-drivers install <name>`` would
+                        install for this driver
+        gpgpu_packages
+                    as  what ``ubuntu-drivers install --gpgpu <name>`` would
+                        install for this driver
 
     Raises:
         RuntimeError: if the apt cache cannot be initialized.
@@ -128,6 +147,11 @@ def _build_drivers_variant() -> GLib.Variant:
         apt_cache=cache, sys_path=sys_path, freeonly=False
     )
 
+    desktop_catalog = UbuntuDrivers.detect.system_driver_packages(
+        cache, sys_path, freeonly=False
+    )
+    gpgpu_catalog = UbuntuDrivers.detect.system_gpgpu_driver_packages(cache, sys_path)
+
     device_list = []
 
     for device_name in sorted(devices):
@@ -140,6 +164,9 @@ def _build_drivers_variant() -> GLib.Variant:
             key=lambda item: (not item[1].get("recommended", False), item[0]),
         ):
             source = "distro" if pkg_info.get("from_distro", False) else "third-party"
+            packages, gpgpu_packages = _package_lists(
+                cache, pkg_name, desktop_catalog, gpgpu_catalog
+            )
             driver_list.append(
                 GLib.Variant(
                     "a{sv}",
@@ -156,9 +183,8 @@ def _build_drivers_variant() -> GLib.Variant:
                         "support": GLib.Variant("s", pkg_info.get("support") or ""),
                         "open_preferred": GLib.Variant(
                             "b", bool(pkg_info.get("open_preferred", False))),
-                        "extra_packages": GLib.Variant(
-                            "as", _extra_packages(cache, pkg_name, pkg_info)
-                        ),
+                        "packages": GLib.Variant("as", packages),
+                        "gpgpu_packages": GLib.Variant("as", gpgpu_packages),
                     },
                 )
             )

--- a/UbuntuDrivers/service/drivers_service.py
+++ b/UbuntuDrivers/service/drivers_service.py
@@ -70,6 +70,7 @@ def _install_list(
             pkg_name,
             get_recommended=False,
             filter_installed=False,
+            skip_runtimepm_marker=True,
         )
 
     return UbuntuDrivers.detect.auto_install_filter(
@@ -79,6 +80,7 @@ def _install_list(
         pkg_name,
         get_recommended=False,
         filter_installed=False,
+        skip_runtimepm_marker=True,
     )
 
 

--- a/tests/test_drivers_service.py
+++ b/tests/test_drivers_service.py
@@ -41,13 +41,21 @@ class _AptChroot:
         self._saved_dir = None
         self._saved_status = None
 
-    def setup(self, archive):
+    def setup(self, archive, installed=()):
+        """Set up the chroot for *archive*.
+
+        installed: paths of .deb files (as returned by
+        testarchive.Archive.create_deb()) to install into the chroot via
+        real `dpkg`, so code that only considers installed packages (e.g.
+        kernel/image detection) can see them as such.
+        """
         for subdir in [
             "var/lib/dpkg",
             "var/cache/apt/archives/partial",
             "var/lib/apt/lists/partial",
             "etc/apt/apt.conf.d",
             "etc/apt/preferences.d",
+            "var/log",
         ]:
             os.makedirs(os.path.join(self.path, subdir), exist_ok=True)
         open(os.path.join(self.path, "var/lib/dpkg/status"), "w").close()
@@ -72,6 +80,22 @@ class _AptChroot:
             check=True,
             capture_output=True,
         )
+
+        for deb_path in installed:
+            subprocess.run(
+                [
+                    "fakeroot",
+                    "dpkg",
+                    "--root",
+                    self.path,
+                    "--log=%s/var/log/dpkg.log" % self.path,
+                    "--force-depends",
+                    "--install",
+                    deb_path,
+                ],
+                check=True,
+                capture_output=True,
+            )
 
         apt_pkg.init_config()
         self._saved_dir = apt_pkg.config.get("Dir", "/")
@@ -621,6 +645,244 @@ class BuildDriversPayloadTests(unittest.TestCase):
             drivers_service._build_drivers_variant()
 
         self.assertIn("apt cache error", str(ctx.exception))
+
+    def test_build_drivers_payload_extra_packages_empty(self):
+        """extra_packages is an empty list when the driver has no metapackage,
+        kernel modules, or LRM package (the fake archive ships none)."""
+        with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
+            result = _call_build_drivers()
+
+        by_device = {os.path.basename(e["sys_path"]): e for e in result}
+        by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
+
+        self.assertEqual(by_name["nvidia-driver-450"]["extra_packages"], [])
+        self.assertEqual(by_name["nvidia-driver-390"]["extra_packages"], [])
+        self.assertEqual(by_name["xserver-xorg-video-nouveau"]["extra_packages"], [])
+        self.assertEqual(by_device["white"]["drivers"][0]["extra_packages"], [])
+
+
+def _gen_fakearchive_with_extras():
+    """Like gen_fakearchive(), plus a real nvidia-driver-lrm-450 package so
+    extra_packages can be exercised end-to-end without mocking the
+    detection helpers.
+    """
+    a = gen_fakearchive()
+    a.create_deb("nvidia-driver-lrm-450")
+    return a
+
+
+class ExtraPackagesIntegrationTests(unittest.TestCase):
+    """End-to-end test of extra_packages through system_device_drivers()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._archive = _gen_fakearchive_with_extras()
+        cls._chroot = _AptChroot()
+        cls._chroot.setup(cls._archive)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_chroot"):
+            cls._chroot.remove()
+
+    def setUp(self):
+        self._umockdev = gen_fakehw()
+        self._plugin_dir = tempfile.mkdtemp()
+        self._old_detect_dir = os.environ.get("UBUNTU_DRIVERS_DETECT_DIR")
+        os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._plugin_dir
+
+    def tearDown(self):
+        shutil.rmtree(self._plugin_dir)
+        if self._old_detect_dir is None:
+            os.environ.pop("UBUNTU_DRIVERS_DETECT_DIR", None)
+        else:
+            os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._old_detect_dir
+
+    def test_extra_packages_includes_real_lrm_package(self):
+        with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
+            result = _call_build_drivers()
+
+        by_device = {os.path.basename(e["sys_path"]): e for e in result}
+        by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
+
+        self.assertEqual(
+            by_name["nvidia-driver-450"]["extra_packages"],
+            ["nvidia-driver-lrm-450"],
+        )
+        # nvidia-driver-390 has no corresponding lrm package in the
+        # archive, so it should report no extras.
+        self.assertEqual(by_name["nvidia-driver-390"]["extra_packages"], [])
+
+
+def _gen_fakearchive_with_prebuilt_modules():
+    """Like gen_fakearchive(), plus a kernel and a matching prebuilt
+    linux-modules-nvidia-450-generic package.
+
+    Returns (archive, installed_deb_paths): the archive, and the .deb paths
+    for the kernel packages that must be installed.
+    """
+    a = gen_fakearchive()
+    kernel_image_deb = a.create_deb("linux-image-5.4.0-25-generic")
+    kernel_meta_deb = a.create_deb(
+        "linux-image-generic",
+        dependencies={"Depends": "linux-image-5.4.0-25-generic"},
+    )
+    a.create_deb(
+        "linux-modules-nvidia-450-5.4.0-25-generic",
+        dependencies={"Depends": "linux-image-5.4.0-25-generic"},
+    )
+    a.create_deb(
+        "linux-modules-nvidia-450-generic",
+        dependencies={"Depends": "linux-modules-nvidia-450-5.4.0-25-generic"},
+    )
+    return a, [kernel_image_deb, kernel_meta_deb]
+
+
+class ExtraPackagesPrebuiltModulesIntegrationTests(unittest.TestCase):
+    """End-to-end test of a driver for which a prebuilt kernel modules
+    package exists for the running kernel, so extra_packages should name it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls._archive, installed = _gen_fakearchive_with_prebuilt_modules()
+        cls._chroot = _AptChroot()
+        cls._chroot.setup(cls._archive, installed=installed)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_chroot"):
+            cls._chroot.remove()
+
+    def setUp(self):
+        self._umockdev = gen_fakehw()
+        self._plugin_dir = tempfile.mkdtemp()
+        self._old_detect_dir = os.environ.get("UBUNTU_DRIVERS_DETECT_DIR")
+        os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._plugin_dir
+
+    def tearDown(self):
+        shutil.rmtree(self._plugin_dir)
+        if self._old_detect_dir is None:
+            os.environ.pop("UBUNTU_DRIVERS_DETECT_DIR", None)
+        else:
+            os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._old_detect_dir
+
+    def test_extra_packages_includes_prebuilt_modules_package(self):
+        with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
+            result = _call_build_drivers()
+
+        by_device = {os.path.basename(e["sys_path"]): e for e in result}
+        by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
+
+        self.assertEqual(
+            by_name["nvidia-driver-450"]["extra_packages"],
+            ["linux-modules-nvidia-450-generic"],
+        )
+        # nvidia-driver-390 has no matching linux-modules-nvidia-390-*
+        # package for this kernel, so it falls back silently to no extras
+        # here (the DKMS fallback itself isn't in this archive either).
+        self.assertEqual(by_name["nvidia-driver-390"]["extra_packages"], [])
+
+
+class ExtraPackagesTests(unittest.TestCase):
+    """Unit tests for _extra_packages() in isolation from apt/hardware state."""
+
+    def test_extra_packages_typical_case_is_just_the_modules_package(self):
+        """No metapackage or LRM package applies, and the driver just needs
+        a single prebuilt kernel modules package for the running kernel."""
+        with (
+            patch(
+                "UbuntuDrivers.detect.get_linux_modules_metapackage",
+                return_value="linux-modules-nvidia-450-generic",
+            ),
+            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
+        ):
+            result = drivers_service._extra_packages(None, "nvidia-driver-450", {})
+
+        self.assertEqual(result, ["linux-modules-nvidia-450-generic"])
+
+    def test_extra_packages_combines_all_sources_in_order(self):
+        """Exercises the general combining/ordering mechanism with all
+        three sources present at once."""
+        pkg_info = {"metapackage": "nvidia-headless-no-dkms-450"}
+        with (
+            patch(
+                "UbuntuDrivers.detect.get_linux_modules_metapackage",
+                return_value="linux-modules-nvidia-450-generic",
+            ),
+            patch(
+                "UbuntuDrivers.detect.get_userspace_lrm_meta",
+                return_value="nvidia-driver-lrm-450",
+            ),
+        ):
+            result = drivers_service._extra_packages(
+                None, "nvidia-driver-450", pkg_info
+            )
+
+        self.assertEqual(
+            result,
+            [
+                "nvidia-headless-no-dkms-450",
+                "linux-modules-nvidia-450-generic",
+                "nvidia-driver-lrm-450",
+            ],
+        )
+
+    def test_extra_packages_no_metapackage_key(self):
+        with (
+            patch(
+                "UbuntuDrivers.detect.get_linux_modules_metapackage",
+                return_value=None,
+            ),
+            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
+        ):
+            result = drivers_service._extra_packages(None, "vanilla", {})
+
+        self.assertEqual(result, [])
+
+    def test_extra_packages_deduplicates(self):
+        pkg_info = {"metapackage": "nvidia-dkms-450"}
+        with (
+            patch(
+                "UbuntuDrivers.detect.get_linux_modules_metapackage",
+                return_value="nvidia-dkms-450",
+            ),
+            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
+        ):
+            result = drivers_service._extra_packages(
+                None, "nvidia-driver-450", pkg_info
+            )
+
+        self.assertEqual(result, ["nvidia-dkms-450"])
+
+    def test_extra_packages_propagates_modules_lookup_exception(self):
+        """An unexpected failure in the modules lookup must not be silently
+        swallowed as "no extra packages"."""
+        pkg_info = {"metapackage": "nvidia-headless-no-dkms-450"}
+        with (
+            patch(
+                "UbuntuDrivers.detect.get_linux_modules_metapackage",
+                side_effect=AssertionError("simulated modules lookup failure"),
+            ),
+            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
+        ):
+            with self.assertRaises(AssertionError):
+                drivers_service._extra_packages(None, "nvidia-driver-450", pkg_info)
+
+    def test_extra_packages_propagates_lrm_lookup_exception(self):
+        """Same as above, for the LRM lookup."""
+        with (
+            patch(
+                "UbuntuDrivers.detect.get_linux_modules_metapackage",
+                return_value=None,
+            ),
+            patch(
+                "UbuntuDrivers.detect.get_userspace_lrm_meta",
+                side_effect=RuntimeError("simulated LRM lookup failure"),
+            ),
+        ):
+            with self.assertRaises(RuntimeError):
+                drivers_service._extra_packages(None, "nvidia-driver-450", {})
 
 
 if __name__ == "__main__":

--- a/tests/test_drivers_service.py
+++ b/tests/test_drivers_service.py
@@ -883,6 +883,7 @@ class InstallListTests(unittest.TestCase):
             "nvidia-driver-450",
             get_recommended=False,
             filter_installed=False,
+            skip_runtimepm_marker=True,
         )
         self.assertEqual(
             result, ["nvidia-driver-450", "linux-modules-nvidia-450-generic"]
@@ -911,6 +912,7 @@ class InstallListTests(unittest.TestCase):
             "nvidia-driver-450",
             get_recommended=False,
             filter_installed=False,
+            skip_runtimepm_marker=True,
         )
         self.assertEqual(result, ["nvidia-headless-no-dkms-450", "nvidia-driver-450"])
 

--- a/tests/test_drivers_service.py
+++ b/tests/test_drivers_service.py
@@ -646,37 +646,181 @@ class BuildDriversPayloadTests(unittest.TestCase):
 
         self.assertIn("apt cache error", str(ctx.exception))
 
-    def test_build_drivers_payload_extra_packages_empty(self):
-        """extra_packages is an empty list when the driver has no metapackage,
-        kernel modules, or LRM package (the fake archive ships none)."""
+    def test_build_drivers_payload_packages_fields(self):
+        """packages/gpgpu_packages report the base driver package"""
         with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
             result = _call_build_drivers()
 
         by_device = {os.path.basename(e["sys_path"]): e for e in result}
         by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
 
-        self.assertEqual(by_name["nvidia-driver-450"]["extra_packages"], [])
-        self.assertEqual(by_name["nvidia-driver-390"]["extra_packages"], [])
-        self.assertEqual(by_name["xserver-xorg-video-nouveau"]["extra_packages"], [])
-        self.assertEqual(by_device["white"]["drivers"][0]["extra_packages"], [])
+        self.assertEqual(
+            by_name["nvidia-driver-450"]["packages"], ["nvidia-driver-450"]
+        )
+        self.assertEqual(
+            by_name["nvidia-driver-450"]["gpgpu_packages"], ["nvidia-driver-450"]
+        )
+        self.assertEqual(
+            by_name["nvidia-driver-390"]["packages"], ["nvidia-driver-390"]
+        )
+        self.assertEqual(
+            by_name["nvidia-driver-390"]["gpgpu_packages"], ["nvidia-driver-390"]
+        )
+        self.assertEqual(by_name["xserver-xorg-video-nouveau"]["packages"], [])
+        self.assertEqual(by_name["xserver-xorg-video-nouveau"]["gpgpu_packages"], [])
+
+        self.assertEqual(by_device["white"]["drivers"][0]["packages"], ["vanilla"])
+        self.assertEqual(by_device["white"]["drivers"][0]["gpgpu_packages"], [])
 
 
-def _gen_fakearchive_with_extras():
-    """Like gen_fakearchive(), plus a real nvidia-driver-lrm-450 package so
-    extra_packages can be exercised end-to-end without mocking the
-    detection helpers.
+def _gen_fakearchive_with_kernel():
+    """Like gen_fakearchive(), plus a kernel and a matching prebuilt
+    linux-modules-nvidia-450-generic package, so the canonical install-list
+    filters have a kernel to resolve a modules package against
+
+    Returns (archive, installed_deb_paths, modules_deb_path)
     """
     a = gen_fakearchive()
-    a.create_deb("nvidia-driver-lrm-450")
-    return a
+    kernel_image_deb = a.create_deb("linux-image-5.4.0-25-generic")
+    kernel_meta_deb = a.create_deb(
+        "linux-image-generic",
+        dependencies={"Depends": "linux-image-5.4.0-25-generic"},
+    )
+    a.create_deb(
+        "linux-modules-nvidia-450-5.4.0-25-generic",
+        dependencies={"Depends": "linux-image-5.4.0-25-generic"},
+    )
+    modules_deb = a.create_deb(
+        "linux-modules-nvidia-450-generic",
+        dependencies={"Depends": "linux-modules-nvidia-450-5.4.0-25-generic"},
+    )
+    return a, [kernel_image_deb, kernel_meta_deb], modules_deb
 
 
-class ExtraPackagesIntegrationTests(unittest.TestCase):
-    """End-to-end test of extra_packages through system_device_drivers()."""
+class PackagesFieldIntegrationTests(unittest.TestCase):
+    """End-to-end tests of the packages/gpgpu_packages fields"""
 
     @classmethod
     def setUpClass(cls):
-        cls._archive = _gen_fakearchive_with_extras()
+        cls._archive, cls._installed, _ = _gen_fakearchive_with_kernel()
+        cls._archive.create_deb("nvidia-driver-lrm-450")
+        cls._chroot = _AptChroot()
+        cls._chroot.setup(cls._archive, installed=cls._installed)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_chroot"):
+            cls._chroot.remove()
+
+    def setUp(self):
+        self._umockdev = gen_fakehw()
+        self._plugin_dir = tempfile.mkdtemp()
+        self._old_detect_dir = os.environ.get("UBUNTU_DRIVERS_DETECT_DIR")
+        os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._plugin_dir
+
+    def tearDown(self):
+        shutil.rmtree(self._plugin_dir)
+        if self._old_detect_dir is None:
+            os.environ.pop("UBUNTU_DRIVERS_DETECT_DIR", None)
+        else:
+            os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._old_detect_dir
+
+    def test_packages_includes_prebuilt_modules_and_lrm_package(self):
+        """With a kernel image installed, the recommended driver's desktop
+        install list includes both its LRM userspace package and the
+        prebuilt kernel modules"""
+        with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
+            result = _call_build_drivers()
+
+        by_device = {os.path.basename(e["sys_path"]): e for e in result}
+        by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
+
+        self.assertEqual(
+            sorted(by_name["nvidia-driver-450"]["packages"]),
+            sorted(
+                [
+                    "nvidia-driver-lrm-450",
+                    "nvidia-driver-450",
+                    "linux-modules-nvidia-450-generic",
+                ]
+            ),
+        )
+        # On the gpgpu (headless) profile, the base nvidia-driver-450
+        # package itself is dropped in favor of its LRM/modules packages.
+        self.assertEqual(
+            sorted(by_name["nvidia-driver-450"]["gpgpu_packages"]),
+            sorted(["nvidia-driver-lrm-450", "linux-modules-nvidia-450-generic"]),
+        )
+        self.assertEqual(
+            by_name["nvidia-driver-390"]["packages"], ["nvidia-driver-390"]
+        )
+        self.assertEqual(
+            by_name["nvidia-driver-390"]["gpgpu_packages"], ["nvidia-driver-390"]
+        )
+
+
+class PackagesFieldAlreadyInstalledIntegrationTests(unittest.TestCase):
+    """D-Bus result reflects the complete install set"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._archive, cls._installed, modules_deb = _gen_fakearchive_with_kernel()
+        lrm_deb = cls._archive.create_deb("nvidia-driver-lrm-450")
+        cls._chroot = _AptChroot()
+        cls._chroot.setup(
+            cls._archive,
+            installed=list(cls._installed) + [modules_deb, lrm_deb],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_chroot"):
+            cls._chroot.remove()
+
+    def setUp(self):
+        self._umockdev = gen_fakehw()
+        self._plugin_dir = tempfile.mkdtemp()
+        self._old_detect_dir = os.environ.get("UBUNTU_DRIVERS_DETECT_DIR")
+        os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._plugin_dir
+
+    def tearDown(self):
+        shutil.rmtree(self._plugin_dir)
+        if self._old_detect_dir is None:
+            os.environ.pop("UBUNTU_DRIVERS_DETECT_DIR", None)
+        else:
+            os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._old_detect_dir
+
+    def test_packages_includes_already_installed_lrm_and_modules(self):
+        with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
+            result = _call_build_drivers()
+
+        by_device = {os.path.basename(e["sys_path"]): e for e in result}
+        by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
+
+        self.assertEqual(
+            sorted(by_name["nvidia-driver-450"]["packages"]),
+            sorted(
+                [
+                    "nvidia-driver-lrm-450",
+                    "nvidia-driver-450",
+                    "linux-modules-nvidia-450-generic",
+                ]
+            ),
+        )
+        self.assertEqual(
+            sorted(by_name["nvidia-driver-450"]["gpgpu_packages"]),
+            sorted(["nvidia-driver-lrm-450", "linux-modules-nvidia-450-generic"]),
+        )
+
+
+class PackagesFieldHeadlessMetapackageIntegrationTests(unittest.TestCase):
+    """End-to-end test of the GPGPU/headless metapackage appearing in
+    gpgpu_packages via gpgpu_install_filter()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._archive = gen_fakearchive()
+        cls._archive.create_deb("nvidia-headless-no-dkms-450")
         cls._chroot = _AptChroot()
         cls._chroot.setup(cls._archive)
 
@@ -698,7 +842,7 @@ class ExtraPackagesIntegrationTests(unittest.TestCase):
         else:
             os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._old_detect_dir
 
-    def test_extra_packages_includes_real_lrm_package(self):
+    def test_gpgpu_packages_includes_headless_metapackage(self):
         with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
             result = _call_build_drivers()
 
@@ -706,183 +850,109 @@ class ExtraPackagesIntegrationTests(unittest.TestCase):
         by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
 
         self.assertEqual(
-            by_name["nvidia-driver-450"]["extra_packages"],
-            ["nvidia-driver-lrm-450"],
+            sorted(by_name["nvidia-driver-450"]["gpgpu_packages"]),
+            sorted(["nvidia-headless-no-dkms-450", "nvidia-driver-450"]),
         )
-        # nvidia-driver-390 has no corresponding lrm package in the
-        # archive, so it should report no extras.
-        self.assertEqual(by_name["nvidia-driver-390"]["extra_packages"], [])
-
-
-def _gen_fakearchive_with_prebuilt_modules():
-    """Like gen_fakearchive(), plus a kernel and a matching prebuilt
-    linux-modules-nvidia-450-generic package.
-
-    Returns (archive, installed_deb_paths): the archive, and the .deb paths
-    for the kernel packages that must be installed.
-    """
-    a = gen_fakearchive()
-    kernel_image_deb = a.create_deb("linux-image-5.4.0-25-generic")
-    kernel_meta_deb = a.create_deb(
-        "linux-image-generic",
-        dependencies={"Depends": "linux-image-5.4.0-25-generic"},
-    )
-    a.create_deb(
-        "linux-modules-nvidia-450-5.4.0-25-generic",
-        dependencies={"Depends": "linux-image-5.4.0-25-generic"},
-    )
-    a.create_deb(
-        "linux-modules-nvidia-450-generic",
-        dependencies={"Depends": "linux-modules-nvidia-450-5.4.0-25-generic"},
-    )
-    return a, [kernel_image_deb, kernel_meta_deb]
-
-
-class ExtraPackagesPrebuiltModulesIntegrationTests(unittest.TestCase):
-    """End-to-end test of a driver for which a prebuilt kernel modules
-    package exists for the running kernel, so extra_packages should name it.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls._archive, installed = _gen_fakearchive_with_prebuilt_modules()
-        cls._chroot = _AptChroot()
-        cls._chroot.setup(cls._archive, installed=installed)
-
-    @classmethod
-    def tearDownClass(cls):
-        if hasattr(cls, "_chroot"):
-            cls._chroot.remove()
-
-    def setUp(self):
-        self._umockdev = gen_fakehw()
-        self._plugin_dir = tempfile.mkdtemp()
-        self._old_detect_dir = os.environ.get("UBUNTU_DRIVERS_DETECT_DIR")
-        os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._plugin_dir
-
-    def tearDown(self):
-        shutil.rmtree(self._plugin_dir)
-        if self._old_detect_dir is None:
-            os.environ.pop("UBUNTU_DRIVERS_DETECT_DIR", None)
-        else:
-            os.environ["UBUNTU_DRIVERS_DETECT_DIR"] = self._old_detect_dir
-
-    def test_extra_packages_includes_prebuilt_modules_package(self):
-        with patch.object(drivers_service, "sys_path", self._umockdev.get_sys_dir()):
-            result = _call_build_drivers()
-
-        by_device = {os.path.basename(e["sys_path"]): e for e in result}
-        by_name = {d["name"]: d for d in by_device["graphics"]["drivers"]}
-
+        # The desktop profile is unaffected: it does not use the headless
+        # metapackage.
         self.assertEqual(
-            by_name["nvidia-driver-450"]["extra_packages"],
-            ["linux-modules-nvidia-450-generic"],
+            by_name["nvidia-driver-450"]["packages"], ["nvidia-driver-450"]
         )
-        # nvidia-driver-390 has no matching linux-modules-nvidia-390-*
-        # package for this kernel, so it falls back silently to no extras
-        # here (the DKMS fallback itself isn't in this archive either).
-        self.assertEqual(by_name["nvidia-driver-390"]["extra_packages"], [])
+        # nvidia-driver-390 has no corresponding headless metapackage in
+        # the archive, so its gpgpu profile is just itself.
+        self.assertEqual(
+            by_name["nvidia-driver-390"]["gpgpu_packages"], ["nvidia-driver-390"]
+        )
 
 
-class ExtraPackagesTests(unittest.TestCase):
-    """Unit tests for _extra_packages() in isolation from apt/hardware state."""
-
-    def test_extra_packages_typical_case_is_just_the_modules_package(self):
-        """No metapackage or LRM package applies, and the driver just needs
-        a single prebuilt kernel modules package for the running kernel."""
-        with (
-            patch(
-                "UbuntuDrivers.detect.get_linux_modules_metapackage",
-                return_value="linux-modules-nvidia-450-generic",
-            ),
-            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
-        ):
-            result = drivers_service._extra_packages(None, "nvidia-driver-450", {})
-
-        self.assertEqual(result, ["linux-modules-nvidia-450-generic"])
-
-    def test_extra_packages_combines_all_sources_in_order(self):
-        """Exercises the general combining/ordering mechanism with all
-        three sources present at once."""
-        pkg_info = {"metapackage": "nvidia-headless-no-dkms-450"}
-        with (
-            patch(
-                "UbuntuDrivers.detect.get_linux_modules_metapackage",
-                return_value="linux-modules-nvidia-450-generic",
-            ),
-            patch(
-                "UbuntuDrivers.detect.get_userspace_lrm_meta",
-                return_value="nvidia-driver-lrm-450",
-            ),
-        ):
-            result = drivers_service._extra_packages(
-                None, "nvidia-driver-450", pkg_info
+class InstallListTests(unittest.TestCase):
+    def test_install_list_desktop(self):
+        catalog = {"nvidia-driver-450": {"free": False, "from_distro": True}}
+        with patch(
+            "UbuntuDrivers.detect.auto_install_filter",
+            return_value=["nvidia-driver-450", "linux-modules-nvidia-450-generic"],
+        ) as mock_filter:
+            result = drivers_service._install_list(
+                None, "nvidia-driver-450", catalog, gpgpu=False
             )
 
+        mock_filter.assert_called_once_with(
+            None,
+            drivers_service._INCLUDE_DKMS,
+            catalog,
+            "nvidia-driver-450",
+            get_recommended=False,
+            filter_installed=False,
+        )
         self.assertEqual(
-            result,
-            [
-                "nvidia-headless-no-dkms-450",
-                "linux-modules-nvidia-450-generic",
-                "nvidia-driver-lrm-450",
-            ],
+            result, ["nvidia-driver-450", "linux-modules-nvidia-450-generic"]
         )
 
-    def test_extra_packages_no_metapackage_key(self):
-        with (
-            patch(
-                "UbuntuDrivers.detect.get_linux_modules_metapackage",
-                return_value=None,
-            ),
-            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
-        ):
-            result = drivers_service._extra_packages(None, "vanilla", {})
+    def test_install_list_gpgpu(self):
+        catalog = {
+            "nvidia-driver-450": {
+                "free": False,
+                "from_distro": True,
+                "metapackage": "nvidia-headless-no-dkms-450",
+            }
+        }
+        with patch(
+            "UbuntuDrivers.detect.gpgpu_install_filter",
+            return_value=["nvidia-headless-no-dkms-450", "nvidia-driver-450"],
+        ) as mock_filter:
+            result = drivers_service._install_list(
+                None, "nvidia-driver-450", catalog, gpgpu=True
+            )
 
+        mock_filter.assert_called_once_with(
+            None,
+            drivers_service._INCLUDE_DKMS,
+            catalog,
+            "nvidia-driver-450",
+            get_recommended=False,
+            filter_installed=False,
+        )
+        self.assertEqual(result, ["nvidia-headless-no-dkms-450", "nvidia-driver-450"])
+
+    def test_install_list_package_not_in_catalog(self):
+        """A package absent from the given catalog is never passed to the filters"""
+        with patch("UbuntuDrivers.detect.auto_install_filter") as mock_filter:
+            result = drivers_service._install_list(
+                None, "xserver-xorg-video-nouveau", {}, gpgpu=False
+            )
+
+        mock_filter.assert_not_called()
         self.assertEqual(result, [])
 
-    def test_extra_packages_deduplicates(self):
-        pkg_info = {"metapackage": "nvidia-dkms-450"}
+    def test_extra_packages_falls_back_for_non_nvidia_package(self):
+        """A non-NVIDIA driver falls back to naming itself"""
+        catalog = {"bcmwl-kernel-source": {"free": False, "from_distro": True}}
         with (
-            patch(
-                "UbuntuDrivers.detect.get_linux_modules_metapackage",
-                return_value="nvidia-dkms-450",
-            ),
-            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
+            patch("UbuntuDrivers.detect.auto_install_filter", return_value=[]),
+            patch("UbuntuDrivers.detect.gpgpu_install_filter", return_value=[]),
         ):
-            result = drivers_service._extra_packages(
-                None, "nvidia-driver-450", pkg_info
+            packages, gpgpu_packages = drivers_service._package_lists(
+                None, "bcmwl-kernel-source", catalog, {}
             )
 
-        self.assertEqual(result, ["nvidia-dkms-450"])
+        self.assertEqual(packages, ["bcmwl-kernel-source"])
+        self.assertEqual(gpgpu_packages, [])
 
-    def test_extra_packages_propagates_modules_lookup_exception(self):
-        """An unexpected failure in the modules lookup must not be silently
-        swallowed as "no extra packages"."""
-        pkg_info = {"metapackage": "nvidia-headless-no-dkms-450"}
+    def test_extra_packages_does_not_pad_empty_nvidia_result(self):
+        """An NVIDIA driver resolving to an empty install list (e.g.
+        because it is already installed) is a meaningful result and must
+        not be padded with a fallback."""
+        catalog = {"nvidia-driver-450": {"free": False, "from_distro": True}}
         with (
-            patch(
-                "UbuntuDrivers.detect.get_linux_modules_metapackage",
-                side_effect=AssertionError("simulated modules lookup failure"),
-            ),
-            patch("UbuntuDrivers.detect.get_userspace_lrm_meta", return_value=None),
+            patch("UbuntuDrivers.detect.auto_install_filter", return_value=[]),
+            patch("UbuntuDrivers.detect.gpgpu_install_filter", return_value=[]),
         ):
-            with self.assertRaises(AssertionError):
-                drivers_service._extra_packages(None, "nvidia-driver-450", pkg_info)
+            packages, gpgpu_packages = drivers_service._package_lists(
+                None, "nvidia-driver-450", catalog, catalog
+            )
 
-    def test_extra_packages_propagates_lrm_lookup_exception(self):
-        """Same as above, for the LRM lookup."""
-        with (
-            patch(
-                "UbuntuDrivers.detect.get_linux_modules_metapackage",
-                return_value=None,
-            ),
-            patch(
-                "UbuntuDrivers.detect.get_userspace_lrm_meta",
-                side_effect=RuntimeError("simulated LRM lookup failure"),
-            ),
-        ):
-            with self.assertRaises(RuntimeError):
-                drivers_service._extra_packages(None, "nvidia-driver-450", {})
+        self.assertEqual(packages, [])
+        self.assertEqual(gpgpu_packages, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_ubuntu_drivers.py
+++ b/tests/test_ubuntu_drivers.py
@@ -6691,6 +6691,58 @@ exec /sbin/modinfo "$@"
             [],
         )
 
+    def test_already_installed_filter_filter_installed_false(self):
+        """already_installed_filter(filter_installed=False) must not wipe
+        the install list to [] just because the metapackage is already
+        installed"""
+
+        chroot = aptdaemon.test.Chroot()
+        try:
+            chroot.setup()
+            chroot.add_test_repository()
+            archive = gen_fakearchive()
+            deb_path = archive.create_deb(
+                "nvidia-driver-410",
+                dependencies={"Depends": "xorg-video-abi-4"},
+                extra_tags={"Modaliases": "nv(pci:v000010DEd000010C3sv*sd*bc03sc*i*)"},
+            )
+            archive.create_deb(
+                "nvidia-headless-no-dkms-410",
+                dependencies={"Depends": "xorg-video-abi-3 | xorg-video-abi-4"},
+            )
+
+            chroot.add_repository(archive.path, True, False)
+            chroot.install_debfile(deb_path, force_depends=True)
+
+            dpkg_status = os.path.abspath(
+                os.path.join(chroot.path, "var", "lib", "dpkg", "status")
+            )
+            apt_pkg.config.set("Dir::State::status", dpkg_status)
+            apt_pkg.init_system()
+            cache = apt_pkg.Cache(None)
+
+            pkgs = {
+                "nvidia-headless-no-dkms-410": {
+                    "metapackage": "nvidia-driver-410",
+                    "recommended": True,
+                },
+            }
+
+            wiped = UbuntuDrivers.detect.already_installed_filter(
+                cache, pkgs, True, gpgpu=True
+            )
+            self.assertEqual(wiped, [])
+
+            kept = UbuntuDrivers.detect.already_installed_filter(
+                cache, pkgs, True, gpgpu=True, filter_installed=False
+            )
+            self.assertEqual(
+                set(kept),
+                set(["nvidia-headless-no-dkms-410", "nvidia-driver-410"]),
+            )
+        finally:
+            chroot.remove()
+
     def test_system_driver_packages_freeonly(self):
         """system_driver_packages() returns only free packages"""
 


### PR DESCRIPTION
Adds a new field to the dbus service output called `packages` and `gpgpu_packages` that contains the other packages `ubuntu-drivers-common` already checks for and installs alongside drivers. This should let consumers know which other packages to install alongside NVIDIA drivers specifically, since they often can come with dkms packages, etc.

Related to https://github.com/canonical/ubuntu-drivers-common/pull/174

---

UDENG-11309